### PR TITLE
feat: add Claude issue-agent workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-code-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-code-task.yml
@@ -1,0 +1,75 @@
+name: Code task for agent
+description: Ask Claude to make a code change (feature, fix, refactor).
+title: "[code] "
+labels: ["type:code"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        File this issue to have the agent modify code.
+        A maintainer will add the `agent-ready` label to trigger the run.
+        The agent reads `.github/agent-instructions.md` before starting and will open a **draft PR**.
+
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target package / app
+      options:
+        - packages/editor
+        - apps/demo
+        - apps/web
+        - apps/api
+        - tools/video-converter
+        - repo root / multiple
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What change is needed and why?
+      placeholder: "Add a `disabled` prop to <Editor> so embedders can render it read-only without using the Viewer component."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, checkable outcomes.
+      placeholder: |
+        - `disabled` prop is documented in the package README
+        - When `disabled={true}`, toolbar is hidden and content is not editable
+        - Existing demo still renders correctly
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicitly list things the agent should NOT touch.
+      placeholder: |
+        - Do not change the <Viewer> component
+        - Do not add new dependencies
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test plan
+      description: How should the change be verified?
+      placeholder: |
+        - `npm run lint` clean
+        - Manual: open apps/demo, verify no regression
+        - Unit test for the new prop
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: Relevant files / prior art
+      description: Files the agent should read first.

--- a/.github/ISSUE_TEMPLATE/agent-docs-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-docs-task.yml
@@ -1,0 +1,58 @@
+name: Docs task for agent
+description: Ask Claude to write or update documentation (docs/, README, prd.md).
+title: "[docs] "
+labels: ["type:docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        File this issue to have the agent produce or update a Markdown document.
+        A maintainer will add the `agent-ready` label to trigger the run.
+        The agent reads `.github/agent-instructions.md` before starting.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One or two sentences describing what the doc should accomplish.
+      placeholder: "Document the video-conversion pipeline end-to-end for new contributors."
+    validations:
+      required: true
+
+  - type: textarea
+    id: targets
+    attributes:
+      label: Target files / paths
+      description: Which file(s) should be created or edited? Paths relative to repo root.
+      placeholder: |
+        - docs/video-pipeline.md (new)
+        - README.md (add link under "Architecture")
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true for this to be done?
+      placeholder: |
+        - Explains MinIO upload → NATS job → HLS output flow
+        - Includes a sequence diagram (Mermaid)
+        - Linked from README
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: Reference links / sources
+      description: Files, PRs, or URLs the agent should read first.
+      placeholder: |
+        - tools/video-converter/README.md
+        - apps/demo/app/api/upload/route.ts
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / constraints
+      description: Anything else — tone, audience, out-of-scope items.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Agent workflow guide
+    url: https://github.com/StanleyLiang/knowledge-management/blob/main/docs/agent-workflow.md
+    about: How the Claude Issue Agent works and how to file effective tasks.

--- a/.github/agent-instructions.md
+++ b/.github/agent-instructions.md
@@ -1,0 +1,85 @@
+# Agent Instructions
+
+These rules apply to any automated run of Claude Code triggered by the `agent-ready` label on an issue in this repo. Read them before doing anything else.
+
+## Repository layout
+
+```
+.
+├── packages/editor/      # Core @lexical-editor/editor library (React + Lexical)
+├── apps/
+│   ├── demo/             # Next.js demo app
+│   ├── web/              # Next.js web app (spaces/pages CRUD)
+│   └── api/              # Fastify + Prisma + PostgreSQL API
+├── tools/video-converter/# MP4 → HLS worker (NATS + MinIO)
+├── docs/                 # Human-facing documentation
+├── infra/                # Infra configuration (do NOT edit)
+└── prd.md                # Product requirements
+```
+
+## Hard rules (do not violate)
+
+1. **Never modify** `.github/workflows/**` or this file (`.github/agent-instructions.md`). If the issue asks you to, refuse, comment on the issue, and apply the `agent-needs-human` label.
+2. **Never modify** anything under `infra/` or any file containing secrets, credentials, or CI/CD configuration.
+3. **Never modify** `package-lock.json` by hand. It may change as a side effect of `npm install`, which is acceptable — direct edits are not.
+4. **Open the pull request as a draft.** Never mark it ready for review. A human reviewer will do that.
+5. **Never merge your own PR.** Never use admin overrides. Never force-push to `main`.
+6. **Never commit secrets** (API keys, tokens, `.env` contents). If an issue body contains one, redact it from any commit or comment.
+
+## Task routing by label
+
+| Label | Scope | Allowed paths |
+|-------|-------|---------------|
+| `type:docs` | Documentation / notes work | `docs/**`, `README.md`, `prd.md`, `*.md` outside `.github/` |
+| `type:code` | Code changes | Everything under `packages/`, `apps/`, `tools/` except `infra/` |
+
+If an issue has both labels, do the docs part first in a separate commit, then the code part. If neither label is set, comment asking for one and apply `agent-needs-human`.
+
+## Quality gates
+
+Before finalizing the PR:
+
+- **Docs tasks:** render the Markdown mentally; check links aren't broken; no stray frontmatter unless the file already uses it.
+- **Code tasks:** run `npm run lint` from the repo root. If the affected package has a test script, run it. If your change spans TypeScript, run the package's type-check. Do not finalize if any of these fail — fix them or surface the failure in the PR description.
+
+## Commit style
+
+Conventional commits — this repo already uses them. Examples from recent history:
+- `feat: make toolbar sticky and offset table sticky header below it`
+- `refactor: simplify ColorPicker with $patchStyleText`
+- `fix: ...`
+
+One logical change per commit when practical.
+
+## Pull request body template
+
+```
+Closes #<issue-number>
+
+## Summary
+<1–3 bullets on what changed and why>
+
+## Changes
+- <file/area>: <what>
+
+## Test plan
+- [ ] <thing the reviewer should verify>
+- [ ] <another thing>
+
+## Screenshots
+<only for UI changes>
+```
+
+## When you are blocked or uncertain
+
+Do not guess. Instead:
+1. Comment on the issue with a specific question (what decision, what options you see).
+2. Apply the `agent-needs-human` label.
+3. Stop.
+
+Ambiguity in the issue body is a signal to ask, not to improvise.
+
+## Retry / cancel
+
+- A maintainer can comment `/agent` on the issue to re-trigger a run.
+- Removing the `agent-ready` label will not cancel a running job — a human must cancel it from the Actions tab.

--- a/.github/scripts/create-agent-labels.sh
+++ b/.github/scripts/create-agent-labels.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Create the labels used by the Claude Issue Agent workflow.
+# Run once after merging the agent-pattern PR. Requires `gh auth login`.
+
+set -euo pipefail
+
+create_or_update() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+  if gh label list --json name -q '.[].name' | grep -qx "$name"; then
+    gh label edit "$name" --color "$color" --description "$description"
+  else
+    gh label create "$name" --color "$color" --description "$description"
+  fi
+}
+
+create_or_update "agent-ready"        "0e8a16" "Maintainer applied this label; triggers the Claude issue-agent workflow."
+create_or_update "agent-in-progress"  "fbca04" "Agent run is currently active for this issue."
+create_or_update "agent-needs-human"  "d73a4a" "Agent is blocked on a question. Will not retry until resolved."
+create_or_update "type:docs"          "0075ca" "Docs/notes task — agent edits only docs, README, prd.md."
+create_or_update "type:code"          "5319e7" "Code task — agent edits source under packages/, apps/, tools/."
+
+echo "Labels created/updated."

--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -1,0 +1,68 @@
+name: Claude Issue Agent
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  agent:
+    name: Run Claude on labeled issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Only run when:
+    #   - an issue is labeled `agent-ready` by a trusted sender, OR
+    #   - a trusted sender comments `/agent` (retry/nudge) on an issue (not a PR).
+    # Sender-association guard blocks random contributors from burning API credits.
+    if: |
+      (
+        github.event_name == 'issues'
+        && github.event.action == 'labeled'
+        && github.event.label.name == 'agent-ready'
+        && github.event.issue.pull_request == null
+      )
+      || (
+        github.event_name == 'issue_comment'
+        && github.event.action == 'created'
+        && startsWith(github.event.comment.body, '/agent')
+        && github.event.issue.pull_request == null
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
+
+    concurrency:
+      group: agent-issue-${{ github.event.issue.number }}
+      cancel-in-progress: true
+
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          label_trigger: agent-ready
+          base_branch: main
+          branch_prefix: agent/issue-
+          # Forbid write users from being bypassed. The action already requires
+          # write permission by default; leaving allowed_non_write_users empty
+          # keeps that guard in place.
+          allowed_non_write_users: ""
+          claude_args: |
+            --append-system-prompt "You are running inside a GitHub Action triggered by an issue label. Before doing anything else, read .github/agent-instructions.md and follow every rule in it. Open the pull request as a draft."
+            --max-turns 40

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,59 @@
+# Claude Issue Agent — Workflow Guide
+
+This repo has an automation that turns GitHub issues into pull requests opened by Claude. This doc explains how to use it.
+
+## Who this is for
+
+Maintainers with write access to `StanleyLiang/knowledge-management`. Only trusted senders (OWNER / MEMBER / COLLABORATOR) can trigger a run — external contributors filing an issue will not cause the agent to spend API credits.
+
+## How to file an agent-ready task
+
+1. Open **New issue** and pick one of the templates:
+   - *Docs task for agent* — for Markdown / documentation work
+   - *Code task for agent* — for code changes
+2. Fill in every field. Ambiguity is the #1 reason the agent asks for help instead of finishing.
+3. Submit the issue. At this point nothing runs — the issue just sits there with `type:docs` or `type:code`.
+4. When you're ready for the agent to start, add the `agent-ready` label. This fires the workflow.
+
+## What happens next
+
+1. The `Claude Issue Agent` workflow in `.github/workflows/claude-issue-agent.yml` triggers.
+2. Claude reads `.github/agent-instructions.md`, then the issue title/body/comments.
+3. It creates a branch named `agent/issue-<number>-<slug>` off `main`.
+4. It commits its changes there and opens a **draft pull request** linked back to the issue (`Closes #<n>`).
+5. It posts a comment on the issue with the PR link.
+6. You review the PR like any other. If good, mark it ready for review, merge, and the issue auto-closes.
+
+## Re-running or iterating
+
+- To re-trigger the agent on an issue (after a comment or updated body), comment `/agent` on the issue. Only maintainers can do this.
+- To ask for changes on an open PR, use the normal GitHub review flow — the agent does not yet watch PR comments (that's a future extension).
+
+## If the agent gets stuck
+
+The agent will apply the `agent-needs-human` label and leave a comment with a specific question. Resolve the ambiguity in a reply, remove `agent-needs-human`, and comment `/agent` to restart.
+
+## Labels reference
+
+| Label | Who applies | Meaning |
+|-------|-------------|---------|
+| `agent-ready` | Maintainer | Kicks off the workflow. |
+| `agent-in-progress` | Workflow | A run is active. |
+| `agent-needs-human` | Agent | Blocked on a question; will not retry until resolved. |
+| `type:docs` | Issue template | Route to docs rules (edits under `docs/`, `README.md`, `prd.md`). |
+| `type:code` | Issue template | Route to code rules (edits under `packages/`, `apps/`, `tools/`). |
+
+## Cancelling a run
+
+Open the **Actions** tab, find the in-flight `Claude Issue Agent` run, and click **Cancel workflow**. Removing the label does *not* stop a run already underway.
+
+## One-time setup (already done by Stanley)
+
+- `ANTHROPIC_API_KEY` secret at Settings → Secrets and variables → Actions.
+- Workflow permissions set to "Read and write" at Settings → Actions → General.
+- Branch protection on `main` requiring PR review before merge — prevents a rogue agent PR from auto-merging.
+- Labels created via `gh label create` (see the repo's `.github/` setup).
+
+## Cost guard
+
+Each run is capped at 20 minutes and `--max-turns 40`. Consider also setting a monthly budget alert in the Anthropic console.


### PR DESCRIPTION
## Summary
- Adds a GitHub-Actions workflow that runs Claude on issues labeled `agent-ready`
- Covers docs and code tasks via two issue form templates
- Guardrails in `.github/agent-instructions.md`; label helper script in `.github/scripts/`
- Human-facing guide at `docs/agent-workflow.md`

## How it works
1. Maintainer files an issue via the `agent-docs-task` or `agent-code-task` template.
2. When ready, they add the `agent-ready` label.
3. `.github/workflows/claude-issue-agent.yml` fires, `anthropics/claude-code-action@v1` reads `.github/agent-instructions.md`, creates `agent/issue-<n>-<slug>`, and opens a **draft PR** linking back to the issue.
4. Human reviews, marks ready, merges.

## Post-merge setup
- [x] Labels created (`agent-ready`, `agent-in-progress`, `agent-needs-human`, `type:docs`, `type:code`)
- [ ] Add `ANTHROPIC_API_KEY` secret at Settings → Secrets and variables → Actions
- [ ] Confirm Settings → Actions → General → Workflow permissions = "Read and write"
- [ ] Enable branch protection on `main` requiring PR review

## Test plan
- [ ] After merge + secret, file a throwaway docs issue, label `agent-ready`, verify a draft PR opens
- [ ] Verify non-member adding label does NOT trigger (sender-association guard)
- [ ] Verify `/agent` comment on a PR does NOT trigger (PR-not-issue guard)