### PR TITLE
chore: disable issue-agent workflow pending billing setup

### DIFF
--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -1,10 +1,11 @@
 name: Claude Issue Agent
 
+# Disabled for now — we're handling agent-ready issues via a local /loop
+# session (Claude Max subscription) instead of the hosted API. Re-enable by
+# restoring `issues: [labeled]` and `issue_comment: [created]` triggers once
+# API billing or a CLAUDE_CODE_OAUTH_TOKEN secret is configured.
 on:
-  issues:
-    types: [labeled]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
Temporarily gates the workflow to `workflow_dispatch` only, because the ANTHROPIC_API_KEY fails with 'Credit balance is too low' — Claude Max doesn't cover API usage. We're switching to a local `/loop` session instead.

Restore the `issues: [labeled]` + `issue_comment: [created]` triggers once either:
- API billing is added at https://console.anthropic.com/settings/billing, or
- A `CLAUDE_CODE_OAUTH_TOKEN` secret is configured (from `claude setup-token`).