### PR TITLE
feat: per-cell table action menu (Row/Column/BG/Header)

### DIFF
--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -22,6 +22,7 @@ import { VideoUploadPlugin } from './plugins/VideoUploadPlugin'
 import { AttachmentUploadPlugin } from './plugins/AttachmentUploadPlugin'
 import { VideoConvertPlugin } from './plugins/VideoConvertPlugin'
 import { TableActionToolbar } from './components/editor/TableActionToolbar'
+import { TableCellActionMenuPlugin } from './plugins/TableCellActionMenuPlugin'
 import { TableColumnResizePlugin } from './plugins/TableColumnResizePlugin'
 import { TableDragReorderPlugin } from './plugins/TableDragReorderPlugin'
 import { SlashCommandPlugin } from './plugins/SlashCommandPlugin'
@@ -177,6 +178,7 @@ export function Editor({
         <LexicalTablePlugin hasHorizontalScroll />
         <TablePlugin />
         <TableActionToolbar />
+        <TableCellActionMenuPlugin />
         <TableColumnResizePlugin />
         <TableDragReorderPlugin />
         <TableActionPlugin />

--- a/packages/editor/src/components/editor/TableActionToolbar.tsx
+++ b/packages/editor/src/components/editor/TableActionToolbar.tsx
@@ -7,33 +7,19 @@ import {
 } from 'lexical'
 import {
   $isTableCellNode,
-  $isTableRowNode,
   $isTableSelection,
   $findTableNode,
   $findCellNode,
-  $insertTableRow__EXPERIMENTAL,
-  $insertTableColumn__EXPERIMENTAL,
-  $deleteTableRow__EXPERIMENTAL,
-  $deleteTableColumn__EXPERIMENTAL,
   $mergeCells,
   $unmergeCell,
-  TableCellHeaderStates,
   type TableCellNode,
   type TableNode,
 } from '@lexical/table'
-import { toast } from '../ui/toast'
 import {
-  checkRowOperation,
-  checkColumnOperation,
-} from '../../utils/tableMergeGuard'
-import {
-  Rows3,
-  Columns3,
   Trash2,
   ChevronDown,
   Merge,
   SplitSquareHorizontal,
-  Paintbrush,
   AlignLeft,
   PanelLeft,
 } from 'lucide-react'
@@ -167,116 +153,6 @@ export function TableActionToolbar() {
     })
   }, [editor])
 
-  /** Run guard check inside read() to keep node access in valid scope */
-  const guardedRowOp = useCallback(
-    (op: 'insert' | 'delete', fn: () => void) => {
-      let blocked: string | null = null
-      editor.getEditorState().read(() => {
-        const selection = $getSelection()
-        let cellNode: TableCellNode | null = null
-        if ($isRangeSelection(selection)) {
-          cellNode = $findCellNode(selection.anchor.getNode()) as TableCellNode | null
-        } else if ($isTableSelection(selection)) {
-          const first = selection.getNodes().find((n) => $isTableCellNode(n))
-          if (first) cellNode = first as TableCellNode
-        }
-        if (!cellNode) return
-        const tableNode = $findTableNode(cellNode) as TableNode | null
-        if (!tableNode) return
-        const row = cellNode.getParent()
-        if (!$isTableRowNode(row)) return
-        const rowIndex = tableNode.getChildren().indexOf(row)
-        blocked = checkRowOperation(tableNode, rowIndex, op)
-      })
-      if (blocked) { toast.warning(blocked); return }
-      fn()
-    },
-    [editor],
-  )
-
-  const guardedColOp = useCallback(
-    (op: 'insert' | 'delete', fn: () => void) => {
-      let blocked: string | null = null
-      editor.getEditorState().read(() => {
-        const selection = $getSelection()
-        let cellNode: TableCellNode | null = null
-        if ($isRangeSelection(selection)) {
-          cellNode = $findCellNode(selection.anchor.getNode()) as TableCellNode | null
-        } else if ($isTableSelection(selection)) {
-          const first = selection.getNodes().find((n) => $isTableCellNode(n))
-          if (first) cellNode = first as TableCellNode
-        }
-        if (!cellNode) return
-        const tableNode = $findTableNode(cellNode) as TableNode | null
-        if (!tableNode) return
-        const row = cellNode.getParent()
-        if (!$isTableRowNode(row)) return
-        const colIndex = row.getChildren().indexOf(cellNode)
-        blocked = checkColumnOperation(tableNode, colIndex, op)
-      })
-      if (blocked) { toast.warning(blocked); return }
-      fn()
-    },
-    [editor],
-  )
-
-  const insertRowAbove = useCallback(() => {
-    guardedRowOp('insert', () => editor.update(() => $insertTableRow__EXPERIMENTAL(false)))
-  }, [editor, guardedRowOp])
-
-  const insertRowBelow = useCallback(() => {
-    guardedRowOp('insert', () => editor.update(() => $insertTableRow__EXPERIMENTAL(true)))
-  }, [editor, guardedRowOp])
-
-  const deleteRow = useCallback(() => {
-    guardedRowOp('delete', () => editor.update(() => $deleteTableRow__EXPERIMENTAL()))
-  }, [editor, guardedRowOp])
-
-  const insertColumnLeft = useCallback(() => {
-    guardedColOp('insert', () => editor.update(() => $insertTableColumn__EXPERIMENTAL(false)))
-  }, [editor, guardedColOp])
-
-  const insertColumnRight = useCallback(() => {
-    guardedColOp('insert', () => editor.update(() => $insertTableColumn__EXPERIMENTAL(true)))
-  }, [editor, guardedColOp])
-
-  const deleteColumn = useCallback(() => {
-    guardedColOp('delete', () => editor.update(() => $deleteTableColumn__EXPERIMENTAL()))
-  }, [editor, guardedColOp])
-
-  const toggleHeader = useCallback(() => {
-    editor.update(() => {
-      const selection = $getSelection()
-      if (!$isRangeSelection(selection)) return
-      const cellNode = $findCellNode(selection.anchor.getNode())
-      if (!cellNode) return
-      const tableNode = $findTableNode(cellNode)
-      if (!tableNode) return
-
-      const firstRow = tableNode.getFirstChild()
-      if (!$isTableRowNode(firstRow)) return
-
-      const cells = firstRow.getChildren()
-      const isCurrentlyHeader =
-        cells.length > 0 &&
-        $isTableCellNode(cells[0]) &&
-        cells[0].getHeaderStyles() === TableCellHeaderStates.ROW
-
-      for (const cell of cells) {
-        if ($isTableCellNode(cell)) {
-          ;(cell as TableCellNode).setHeaderStyles(
-            isCurrentlyHeader
-              ? TableCellHeaderStates.NO_STATUS
-              : TableCellHeaderStates.ROW,
-          )
-        }
-      }
-
-      // Sync frozen row state for sticky header
-      ;(tableNode as TableNode).setFrozenRows(isCurrentlyHeader ? 0 : 1)
-    })
-  }, [editor])
-
   const mergeCells = useCallback(() => {
     editor.update(() => {
       const selection = $getSelection()
@@ -294,25 +170,6 @@ export function TableActionToolbar() {
       $unmergeCell()
     })
   }, [editor])
-
-  const setCellBgColor = useCallback(
-    (color: string) => {
-      editor.update(() => {
-        const selection = $getSelection()
-        let cells: TableCellNode[] = []
-        if ($isTableSelection(selection)) {
-          cells = selection.getNodes().filter((n) => $isTableCellNode(n)) as TableCellNode[]
-        } else if ($isRangeSelection(selection)) {
-          const cell = $findCellNode(selection.anchor.getNode())
-          if (cell) cells = [cell as TableCellNode]
-        }
-        for (const cell of cells) {
-          cell.setBackgroundColor(color)
-        }
-      })
-    },
-    [editor],
-  )
 
   const setCellAlign = useCallback(
     (align: 'left' | 'center' | 'right') => {
@@ -383,25 +240,6 @@ export function TableActionToolbar() {
         }
       }}
     >
-      <ToolbarDropdown
-        icon={Rows3}
-        label="Row"
-        items={[
-          { label: 'Insert Row Above', action: insertRowAbove },
-          { label: 'Insert Row Below', action: insertRowBelow },
-          { label: 'Delete Row', action: deleteRow },
-        ]}
-      />
-      <ToolbarDropdown
-        icon={Columns3}
-        label="Column"
-        items={[
-          { label: 'Insert Column Left', action: insertColumnLeft },
-          { label: 'Insert Column Right', action: insertColumnRight },
-          { label: 'Delete Column', action: deleteColumn },
-        ]}
-      />
-      <div className="le-table-toolbar-sep" />
       {canMerge && (
         <button className="le-table-toolbar-btn" onClick={mergeCells} title="Merge Cells">
           <Merge size={14} />
@@ -416,19 +254,6 @@ export function TableActionToolbar() {
       )}
       {(canMerge || canSplit) && <div className="le-table-toolbar-sep" />}
       <ToolbarDropdown
-        icon={Paintbrush}
-        label="BG"
-        items={[
-          { label: '⬜ None', action: () => setCellBgColor('') },
-          { label: '🔵 Blue', action: () => setCellBgColor('#dbeafe') },
-          { label: '🟢 Green', action: () => setCellBgColor('#dcfce7') },
-          { label: '🟡 Yellow', action: () => setCellBgColor('#fef9c3') },
-          { label: '🔴 Red', action: () => setCellBgColor('#fee2e2') },
-          { label: '🟣 Purple', action: () => setCellBgColor('#f3e8ff') },
-          { label: '⚫ Gray', action: () => setCellBgColor('#f3f4f6') },
-        ]}
-      />
-      <ToolbarDropdown
         icon={AlignLeft}
         label="Align"
         items={[
@@ -438,9 +263,6 @@ export function TableActionToolbar() {
         ]}
       />
       <div className="le-table-toolbar-sep" />
-      <button className="le-table-toolbar-btn" onClick={toggleHeader} title="Toggle Header Row">
-        <span className="le-table-toolbar-btn-label">Header</span>
-      </button>
       <ToolbarDropdown
         icon={PanelLeft}
         label="Freeze"

--- a/packages/editor/src/plugins/TableCellActionMenuPlugin.tsx
+++ b/packages/editor/src/plugins/TableCellActionMenuPlugin.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import {
+  $getSelection,
+  $isRangeSelection,
+} from 'lexical'
+import {
+  $isTableCellNode,
+  $isTableRowNode,
+  $isTableSelection,
+  $findTableNode,
+  $findCellNode,
+  $insertTableRow__EXPERIMENTAL,
+  $insertTableColumn__EXPERIMENTAL,
+  $deleteTableRow__EXPERIMENTAL,
+  $deleteTableColumn__EXPERIMENTAL,
+  TableCellHeaderStates,
+  type TableCellNode,
+  type TableNode,
+} from '@lexical/table'
+import { ChevronDown } from 'lucide-react'
+import { toast } from '../components/ui/toast'
+import {
+  checkRowOperation,
+  checkColumnOperation,
+} from '../utils/tableMergeGuard'
+
+type Section = 'row' | 'column' | 'bg' | 'header'
+
+const BG_COLORS: { label: string; value: string }[] = [
+  { label: 'None', value: '' },
+  { label: 'Blue', value: '#dbeafe' },
+  { label: 'Green', value: '#dcfce7' },
+  { label: 'Yellow', value: '#fef9c3' },
+  { label: 'Red', value: '#fee2e2' },
+  { label: 'Purple', value: '#f3e8ff' },
+  { label: 'Gray', value: '#f3f4f6' },
+]
+
+export function TableCellActionMenuPlugin() {
+  const [editor] = useLexicalComposerContext()
+  const [cellKey, setCellKey] = useState<string | null>(null)
+  const [position, setPosition] = useState({ top: 0, left: 0 })
+  const [show, setShow] = useState(false)
+  const [open, setOpen] = useState<Section | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    return editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        const selection = $getSelection()
+
+        let cellNode: TableCellNode | null = null
+        if ($isRangeSelection(selection)) {
+          cellNode = $findCellNode(selection.anchor.getNode()) as TableCellNode | null
+        } else if ($isTableSelection(selection)) {
+          const first = selection.getNodes().find((n) => $isTableCellNode(n))
+          if (first) cellNode = first as TableCellNode
+        }
+
+        if (!cellNode) {
+          setShow(false)
+          setCellKey(null)
+          return
+        }
+
+        const cellEl = editor.getElementByKey(cellNode.getKey())
+        const editorRoot = editor.getRootElement()
+        if (!cellEl || !editorRoot) {
+          setShow(false)
+          return
+        }
+
+        const cellRect = cellEl.getBoundingClientRect()
+        const rootRect = editorRoot.getBoundingClientRect()
+
+        setPosition({
+          top: cellRect.top - rootRect.top + 4,
+          left: cellRect.right - rootRect.left - 24,
+        })
+        setCellKey(cellNode.getKey())
+        setShow(true)
+      })
+    })
+  }, [editor])
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(null)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const guardedRowOp = useCallback(
+    (op: 'insert' | 'delete', fn: () => void) => {
+      let blocked: string | null = null
+      editor.getEditorState().read(() => {
+        const selection = $getSelection()
+        let cellNode: TableCellNode | null = null
+        if ($isRangeSelection(selection)) {
+          cellNode = $findCellNode(selection.anchor.getNode()) as TableCellNode | null
+        } else if ($isTableSelection(selection)) {
+          const first = selection.getNodes().find((n) => $isTableCellNode(n))
+          if (first) cellNode = first as TableCellNode
+        }
+        if (!cellNode) return
+        const tableNode = $findTableNode(cellNode) as TableNode | null
+        if (!tableNode) return
+        const row = cellNode.getParent()
+        if (!$isTableRowNode(row)) return
+        const rowIndex = tableNode.getChildren().indexOf(row)
+        blocked = checkRowOperation(tableNode, rowIndex, op)
+      })
+      if (blocked) { toast.warning(blocked); return }
+      fn()
+    },
+    [editor],
+  )
+
+  const guardedColOp = useCallback(
+    (op: 'insert' | 'delete', fn: () => void) => {
+      let blocked: string | null = null
+      editor.getEditorState().read(() => {
+        const selection = $getSelection()
+        let cellNode: TableCellNode | null = null
+        if ($isRangeSelection(selection)) {
+          cellNode = $findCellNode(selection.anchor.getNode()) as TableCellNode | null
+        } else if ($isTableSelection(selection)) {
+          const first = selection.getNodes().find((n) => $isTableCellNode(n))
+          if (first) cellNode = first as TableCellNode
+        }
+        if (!cellNode) return
+        const tableNode = $findTableNode(cellNode) as TableNode | null
+        if (!tableNode) return
+        const row = cellNode.getParent()
+        if (!$isTableRowNode(row)) return
+        const colIndex = row.getChildren().indexOf(cellNode)
+        blocked = checkColumnOperation(tableNode, colIndex, op)
+      })
+      if (blocked) { toast.warning(blocked); return }
+      fn()
+    },
+    [editor],
+  )
+
+  const runRow = (direction: 'above' | 'below') =>
+    guardedRowOp('insert', () =>
+      editor.update(() => $insertTableRow__EXPERIMENTAL(direction === 'below')),
+    )
+  const runDeleteRow = () =>
+    guardedRowOp('delete', () => editor.update(() => $deleteTableRow__EXPERIMENTAL()))
+  const runCol = (direction: 'left' | 'right') =>
+    guardedColOp('insert', () =>
+      editor.update(() => $insertTableColumn__EXPERIMENTAL(direction === 'right')),
+    )
+  const runDeleteCol = () =>
+    guardedColOp('delete', () => editor.update(() => $deleteTableColumn__EXPERIMENTAL()))
+
+  const setBg = (color: string) => {
+    editor.update(() => {
+      const selection = $getSelection()
+      let cells: TableCellNode[] = []
+      if ($isTableSelection(selection)) {
+        cells = selection.getNodes().filter((n) => $isTableCellNode(n)) as TableCellNode[]
+      } else if ($isRangeSelection(selection)) {
+        const cell = $findCellNode(selection.anchor.getNode())
+        if (cell) cells = [cell as TableCellNode]
+      }
+      for (const cell of cells) cell.setBackgroundColor(color)
+    })
+  }
+
+  const toggleHeader = () => {
+    editor.update(() => {
+      const selection = $getSelection()
+      if (!$isRangeSelection(selection)) return
+      const cellNode = $findCellNode(selection.anchor.getNode())
+      if (!cellNode) return
+      const tableNode = $findTableNode(cellNode)
+      if (!tableNode) return
+
+      const firstRow = tableNode.getFirstChild()
+      if (!$isTableRowNode(firstRow)) return
+
+      const cells = firstRow.getChildren()
+      const isCurrentlyHeader =
+        cells.length > 0 &&
+        $isTableCellNode(cells[0]) &&
+        cells[0].getHeaderStyles() === TableCellHeaderStates.ROW
+
+      for (const cell of cells) {
+        if ($isTableCellNode(cell)) {
+          ;(cell as TableCellNode).setHeaderStyles(
+            isCurrentlyHeader
+              ? TableCellHeaderStates.NO_STATUS
+              : TableCellHeaderStates.ROW,
+          )
+        }
+      }
+
+      ;(tableNode as TableNode).setFrozenRows(isCurrentlyHeader ? 0 : 1)
+    })
+  }
+
+  const runAndClose = (fn: () => void) => {
+    fn()
+    setOpen(null)
+  }
+
+  if (!show || !cellKey) return null
+
+  const editorRoot = editor.getRootElement()
+  const portalTarget = editorRoot?.parentElement ?? document.body
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="le-table-cell-action"
+      style={{ top: position.top, left: position.left }}
+      onMouseDown={(e) => {
+        const target = e.target as HTMLElement
+        if (target.tagName !== 'INPUT' && target.tagName !== 'TEXTAREA') {
+          e.preventDefault()
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="le-table-cell-action-button"
+        title="Cell actions"
+        onClick={() => setOpen(open ? null : 'row')}
+      >
+        <ChevronDown size={12} />
+      </button>
+      {open && (
+        <div className="le-table-cell-action-menu">
+          <div className="le-table-cell-action-tabs">
+            {(['row', 'column', 'bg', 'header'] as Section[]).map((s) => (
+              <button
+                key={s}
+                type="button"
+                className={
+                  'le-table-cell-action-tab' +
+                  (open === s ? ' le-table-cell-action-tab-active' : '')
+                }
+                onClick={() => setOpen(s)}
+              >
+                {s === 'bg' ? 'BG' : s[0].toUpperCase() + s.slice(1)}
+              </button>
+            ))}
+          </div>
+          <div className="le-table-cell-action-panel">
+            {open === 'row' && (
+              <>
+                <button className="le-table-cell-action-item" onClick={() => runAndClose(() => runRow('above'))}>Insert Row Above</button>
+                <button className="le-table-cell-action-item" onClick={() => runAndClose(() => runRow('below'))}>Insert Row Below</button>
+                <button className="le-table-cell-action-item le-table-cell-action-item-danger" onClick={() => runAndClose(runDeleteRow)}>Delete Row</button>
+              </>
+            )}
+            {open === 'column' && (
+              <>
+                <button className="le-table-cell-action-item" onClick={() => runAndClose(() => runCol('left'))}>Insert Column Left</button>
+                <button className="le-table-cell-action-item" onClick={() => runAndClose(() => runCol('right'))}>Insert Column Right</button>
+                <button className="le-table-cell-action-item le-table-cell-action-item-danger" onClick={() => runAndClose(runDeleteCol)}>Delete Column</button>
+              </>
+            )}
+            {open === 'bg' && (
+              <div className="le-table-cell-action-swatches">
+                {BG_COLORS.map((c) => (
+                  <button
+                    key={c.label}
+                    type="button"
+                    className="le-table-cell-action-swatch"
+                    title={c.label}
+                    style={{ background: c.value || 'transparent' }}
+                    onClick={() => runAndClose(() => setBg(c.value))}
+                  >
+                    {!c.value && <span className="le-table-cell-action-swatch-none">∅</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+            {open === 'header' && (
+              <button className="le-table-cell-action-item" onClick={() => runAndClose(toggleHeader)}>
+                Toggle Header Row
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>,
+    portalTarget,
+  )
+}

--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -203,6 +203,51 @@
          hover:bg-gray-100 transition-colors;
 }
 
+/* Table Cell Action Menu (per-cell button + dropdown) */
+.le-table-cell-action {
+  @apply absolute z-40;
+}
+.le-table-cell-action-button {
+  @apply flex items-center justify-center w-5 h-5 rounded
+         bg-white/90 border border-gray-200 text-gray-500
+         hover:text-gray-800 hover:bg-white shadow-sm
+         transition-colors;
+}
+.le-table-cell-action-menu {
+  @apply absolute top-6 right-0 bg-white border border-gray-200
+         rounded-lg shadow-lg min-w-[180px] z-50 overflow-hidden;
+}
+.le-table-cell-action-tabs {
+  @apply flex border-b border-gray-200 bg-gray-50;
+}
+.le-table-cell-action-tab {
+  @apply flex-1 px-2 py-1.5 text-xs text-gray-600
+         hover:bg-gray-100 transition-colors;
+}
+.le-table-cell-action-tab-active {
+  @apply bg-white text-gray-900 font-medium;
+}
+.le-table-cell-action-panel {
+  @apply py-1;
+}
+.le-table-cell-action-item {
+  @apply w-full text-left px-3 py-1.5 text-xs text-gray-700
+         hover:bg-gray-100 transition-colors;
+}
+.le-table-cell-action-item-danger {
+  @apply text-red-600 hover:bg-red-50;
+}
+.le-table-cell-action-swatches {
+  @apply grid grid-cols-4 gap-1 p-2;
+}
+.le-table-cell-action-swatch {
+  @apply w-6 h-6 rounded border border-gray-200 hover:ring-2
+         hover:ring-blue-300 transition-all flex items-center justify-center;
+}
+.le-table-cell-action-swatch-none {
+  @apply text-xs text-gray-400;
+}
+
 /* Table drag handles */
 .le-table-drag-handle {
   @apply absolute flex items-center justify-center text-gray-300


### PR DESCRIPTION
## Summary

Implements the per-cell action button requested in #7. A small chevron button now appears at the top-right of the focused table cell; clicking it opens a tabbed dropdown with **Row**, **Column**, **BG**, and **Header** sections. The floating \`TableActionToolbar\` no longer owns those sections — it keeps only cross-cell operations (Merge, Split, Align) and table-level actions (Freeze, Delete).

- New plugin: \`packages/editor/src/plugins/TableCellActionMenuPlugin.tsx\`
- Simplified: \`packages/editor/src/components/editor/TableActionToolbar.tsx\`
- New \`le-table-cell-action-*\` styles in \`packages/editor/src/styles/editor.css\`
- Wired into \`packages/editor/src/Editor.tsx\`

## Test plan

- [ ] Click into a table cell — chevron button shows at top-right
- [ ] Row tab: Insert Above / Below / Delete Row (guarded by merge check)
- [ ] Column tab: Insert Left / Right / Delete Column (guarded by merge check)
- [ ] BG tab: swatch applies background to focused / selected cells
- [ ] Header tab: toggles row-header state on first row
- [ ] Floating toolbar still shows Align, Freeze, Delete (and Merge/Split when multi-cell selected)
- [ ] \`npm run build\` succeeds (verified)

Closes #7