### PR TITLE
fix: make table cell action button visible and hover-tracked

### DIFF
--- a/packages/editor/src/plugins/TableCellActionMenuPlugin.tsx
+++ b/packages/editor/src/plugins/TableCellActionMenuPlugin.tsx
@@ -46,6 +46,20 @@ export function TableCellActionMenuPlugin() {
   const [open, setOpen] = useState<Section | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
+  const positionFor = useCallback(
+    (cellEl: HTMLElement) => {
+      const editorRoot = editor.getRootElement()
+      if (!editorRoot) return null
+      const cellRect = cellEl.getBoundingClientRect()
+      const rootRect = editorRoot.getBoundingClientRect()
+      return {
+        top: cellRect.top - rootRect.top + 6,
+        left: cellRect.right - rootRect.left - 28,
+      }
+    },
+    [editor],
+  )
+
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState }) => {
       editorState.read(() => {
@@ -59,31 +73,53 @@ export function TableCellActionMenuPlugin() {
           if (first) cellNode = first as TableCellNode
         }
 
-        if (!cellNode) {
-          setShow(false)
-          setCellKey(null)
-          return
-        }
+        if (!cellNode) return
 
-        const cellEl = editor.getElementByKey(cellNode.getKey())
-        const editorRoot = editor.getRootElement()
-        if (!cellEl || !editorRoot) {
-          setShow(false)
-          return
-        }
+        const cellEl = editor.getElementByKey(cellNode.getKey()) as HTMLElement | null
+        if (!cellEl) return
 
-        const cellRect = cellEl.getBoundingClientRect()
-        const rootRect = editorRoot.getBoundingClientRect()
-
-        setPosition({
-          top: cellRect.top - rootRect.top + 4,
-          left: cellRect.right - rootRect.left - 24,
-        })
+        const pos = positionFor(cellEl)
+        if (!pos) return
+        setPosition(pos)
         setCellKey(cellNode.getKey())
         setShow(true)
       })
     })
-  }, [editor])
+  }, [editor, positionFor])
+
+  useEffect(() => {
+    const editorRoot = editor.getRootElement()
+    if (!editorRoot) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null
+      if (!target) return
+      if (menuRef.current && menuRef.current.contains(target)) return
+      const cellEl = target.closest('th, td') as HTMLElement | null
+      if (!cellEl || !editorRoot.contains(cellEl)) return
+      const pos = positionFor(cellEl)
+      if (!pos) return
+      setPosition(pos)
+      setCellKey(cellEl.getAttribute('data-lexical-key') || 'hover')
+      setShow(true)
+    }
+
+    const handleMouseLeave = (e: MouseEvent) => {
+      const related = e.relatedTarget as Node | null
+      if (menuRef.current && related && menuRef.current.contains(related)) return
+      if (open) return
+      const to = related as HTMLElement | null
+      if (to && to.closest && to.closest('th, td') && editorRoot.contains(to)) return
+      setShow(false)
+    }
+
+    editorRoot.addEventListener('mousemove', handleMouseMove)
+    editorRoot.addEventListener('mouseleave', handleMouseLeave)
+    return () => {
+      editorRoot.removeEventListener('mousemove', handleMouseMove)
+      editorRoot.removeEventListener('mouseleave', handleMouseLeave)
+    }
+  }, [editor, positionFor, open])
 
   useEffect(() => {
     if (!open) return
@@ -235,7 +271,7 @@ export function TableCellActionMenuPlugin() {
         title="Cell actions"
         onClick={() => setOpen(open ? null : 'row')}
       >
-        <ChevronDown size={12} />
+        <ChevronDown size={14} />
       </button>
       {open && (
         <div className="le-table-cell-action-menu">

--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -208,9 +208,9 @@
   @apply absolute z-40;
 }
 .le-table-cell-action-button {
-  @apply flex items-center justify-center w-5 h-5 rounded
-         bg-white/90 border border-gray-200 text-gray-500
-         hover:text-gray-800 hover:bg-white shadow-sm
+  @apply flex items-center justify-center w-6 h-6 rounded-md
+         bg-gray-700 border border-gray-800 text-white
+         hover:bg-gray-900 shadow-md cursor-pointer
          transition-colors;
 }
 .le-table-cell-action-menu {


### PR DESCRIPTION
## Summary

Issue #9 reported that the cell action button from PR #8 was invisible in practice. Two fixes:

- **Visual prominence**: button was 20x20 with a white-on-white border and a small chevron — practically invisible on a white cell. It's now 24x24 with a dark gray background and a white chevron, so it reads as a button against any cell fill.
- **Hover tracking**: previously the button only appeared when a cell was *focused* (i.e. after clicking into it). Lexical playground shows it on cell hover. Added a `mousemove` listener on the editor root that positions the button at the hovered `th`/`td`. The selection-driven path still works.

## Test plan

- [ ] Hover any table cell — dark chevron button appears at top-right
- [ ] Move pointer between cells — button follows the cell under the cursor
- [ ] Click button — tabbed menu opens (Row / Column / BG / Header)
- [ ] Click a menu item — action runs and menu closes
- [ ] Move pointer out of table — button disappears (unless menu is open)
- [ ] \`npm run build\` succeeds (verified)

Closes #9