### PR TITLE
feat: AI-powered note cluster synthesis (#12)

### DIFF
--- a/apps/api/prisma/migrations/20260422000000_add_syntheses/migration.sql
+++ b/apps/api/prisma/migrations/20260422000000_add_syntheses/migration.sql
@@ -1,0 +1,60 @@
+-- CreateEnum
+CREATE TYPE "SynthesisStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED', 'EDITED');
+
+-- CreateTable
+CREATE TABLE "page_embeddings" (
+    "page_id" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "content_hash" TEXT NOT NULL,
+    "vector" DOUBLE PRECISION[],
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "page_embeddings_pkey" PRIMARY KEY ("page_id")
+);
+
+-- CreateTable
+CREATE TABLE "syntheses" (
+    "id" TEXT NOT NULL,
+    "space_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "contradictions" TEXT NOT NULL,
+    "open_questions" TEXT NOT NULL,
+    "cluster_key" TEXT NOT NULL,
+    "status" "SynthesisStatus" NOT NULL DEFAULT 'PENDING',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "syntheses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "synthesis_sources" (
+    "synthesis_id" TEXT NOT NULL,
+    "page_id" TEXT NOT NULL,
+    "snippet" TEXT,
+
+    CONSTRAINT "synthesis_sources_pkey" PRIMARY KEY ("synthesis_id","page_id")
+);
+
+-- CreateIndex
+CREATE INDEX "syntheses_space_id_idx" ON "syntheses"("space_id");
+
+-- CreateIndex
+CREATE INDEX "syntheses_cluster_key_idx" ON "syntheses"("cluster_key");
+
+-- CreateIndex
+CREATE INDEX "synthesis_sources_page_id_idx" ON "synthesis_sources"("page_id");
+
+-- AddForeignKey
+ALTER TABLE "page_embeddings" ADD CONSTRAINT "page_embeddings_page_id_fkey" FOREIGN KEY ("page_id") REFERENCES "pages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "syntheses" ADD CONSTRAINT "syntheses_space_id_fkey" FOREIGN KEY ("space_id") REFERENCES "spaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "synthesis_sources" ADD CONSTRAINT "synthesis_sources_synthesis_id_fkey" FOREIGN KEY ("synthesis_id") REFERENCES "syntheses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "synthesis_sources" ADD CONSTRAINT "synthesis_sources_page_id_fkey" FOREIGN KEY ("page_id") REFERENCES "pages"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -8,32 +8,35 @@ datasource db {
 }
 
 model Space {
-  id          String    @id @default(cuid())
+  id          String      @id @default(cuid())
   name        String
   description String?
-  type        SpaceType @default(TEAM)
-  createdAt   DateTime  @default(now()) @map("created_at")
-  updatedAt   DateTime  @updatedAt @map("updated_at")
+  type        SpaceType   @default(TEAM)
+  createdAt   DateTime    @default(now()) @map("created_at")
+  updatedAt   DateTime    @updatedAt @map("updated_at")
   pages       Page[]
+  syntheses   Synthesis[]
 
   @@map("spaces")
 }
 
 model Page {
-  id                 String        @id @default(cuid())
-  title              String        @default("Untitled")
-  content            Json?         @db.JsonB
-  status             PageStatus    @default(DRAFT)
+  id                 String              @id @default(cuid())
+  title              String              @default("Untitled")
+  content            Json?               @db.JsonB
+  status             PageStatus          @default(DRAFT)
   author             String?
-  publishedVersionId String?       @map("published_version_id")
-  spaceId            String        @map("space_id")
-  space              Space         @relation(fields: [spaceId], references: [id], onDelete: Cascade)
-  parentId           String?       @map("parent_id")
-  parent             Page?         @relation("PageChildren", fields: [parentId], references: [id], onDelete: Cascade)
-  children           Page[]        @relation("PageChildren")
+  publishedVersionId String?             @map("published_version_id")
+  spaceId            String              @map("space_id")
+  space              Space               @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  parentId           String?             @map("parent_id")
+  parent             Page?               @relation("PageChildren", fields: [parentId], references: [id], onDelete: Cascade)
+  children           Page[]              @relation("PageChildren")
   versions           PageVersion[]
-  createdAt          DateTime      @default(now()) @map("created_at")
-  updatedAt          DateTime      @updatedAt @map("updated_at")
+  embedding          PageEmbedding?
+  synthesisSources   SynthesisSource[]
+  createdAt          DateTime            @default(now()) @map("created_at")
+  updatedAt          DateTime            @updatedAt @map("updated_at")
 
   @@index([spaceId])
   @@index([parentId])
@@ -52,6 +55,49 @@ model PageVersion {
 
   @@index([pageId])
   @@map("page_versions")
+}
+
+model PageEmbedding {
+  pageId    String   @id @map("page_id")
+  page      Page     @relation(fields: [pageId], references: [id], onDelete: Cascade)
+  model     String
+  contentHash String @map("content_hash")
+  vector    Float[]
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("page_embeddings")
+}
+
+model Synthesis {
+  id               String            @id @default(cuid())
+  spaceId          String            @map("space_id")
+  space            Space             @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  title            String
+  summary          String
+  contradictions   String
+  openQuestions    String            @map("open_questions")
+  clusterKey       String            @map("cluster_key")
+  status           SynthesisStatus   @default(PENDING)
+  sources          SynthesisSource[]
+  createdAt        DateTime          @default(now()) @map("created_at")
+  updatedAt        DateTime          @updatedAt @map("updated_at")
+
+  @@index([spaceId])
+  @@index([clusterKey])
+  @@map("syntheses")
+}
+
+model SynthesisSource {
+  synthesisId String    @map("synthesis_id")
+  synthesis   Synthesis @relation(fields: [synthesisId], references: [id], onDelete: Cascade)
+  pageId      String    @map("page_id")
+  page        Page      @relation(fields: [pageId], references: [id], onDelete: Cascade)
+  snippet     String?
+
+  @@id([synthesisId, pageId])
+  @@index([pageId])
+  @@map("synthesis_sources")
 }
 
 model PageTemplate {
@@ -76,4 +122,11 @@ enum SpaceType {
   PERSONAL
   TEAM
   OFFICIAL
+}
+
+enum SynthesisStatus {
+  PENDING
+  ACCEPTED
+  REJECTED
+  EDITED
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import { spaceRoutes } from './routes/spaces.js'
 import { pageRoutes } from './routes/pages.js'
 import { searchRoutes } from './routes/search.js'
 import { templateRoutes } from './routes/templates.js'
+import { synthesisRoutes } from './routes/syntheses.js'
 
 export async function buildApp() {
   const app = Fastify({ logger: true })
@@ -13,6 +14,7 @@ export async function buildApp() {
   await app.register(pageRoutes, { prefix: '/api' })
   await app.register(searchRoutes, { prefix: '/api' })
   await app.register(templateRoutes, { prefix: '/api' })
+  await app.register(synthesisRoutes, { prefix: '/api' })
 
   return app
 }

--- a/apps/api/src/lib/synthesis/cluster.ts
+++ b/apps/api/src/lib/synthesis/cluster.ts
@@ -1,0 +1,83 @@
+// DBSCAN clustering over a set of embedding vectors using cosine distance.
+// Pure function — no I/O — so it can be unit-tested and reused in scripts.
+
+export interface ClusterPoint {
+  id: string
+  vector: number[]
+}
+
+export interface ClusterResult {
+  clusters: string[][]
+  noise: string[]
+}
+
+export interface DbscanOptions {
+  // Max cosine distance (1 - cosine similarity) for two points to be neighbors.
+  eps: number
+  // Minimum neighborhood size for a core point.
+  minPoints: number
+}
+
+export function cosineDistance(a: number[], b: number[]): number {
+  if (a.length !== b.length) throw new Error('vector length mismatch')
+  let dot = 0
+  let na = 0
+  let nb = 0
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i]
+    na += a[i] * a[i]
+    nb += b[i] * b[i]
+  }
+  if (na === 0 || nb === 0) return 1
+  return 1 - dot / (Math.sqrt(na) * Math.sqrt(nb))
+}
+
+export function dbscan(points: ClusterPoint[], opts: DbscanOptions): ClusterResult {
+  const n = points.length
+  const labels = new Array<number>(n).fill(-1) // -1 = unclassified, 0 = noise
+  let clusterId = 0
+
+  const neighbors = (i: number): number[] => {
+    const out: number[] = []
+    for (let j = 0; j < n; j++) {
+      if (i === j) continue
+      if (cosineDistance(points[i].vector, points[j].vector) <= opts.eps) out.push(j)
+    }
+    return out
+  }
+
+  for (let i = 0; i < n; i++) {
+    if (labels[i] !== -1) continue
+    const seeds = neighbors(i)
+    if (seeds.length + 1 < opts.minPoints) {
+      labels[i] = 0
+      continue
+    }
+    clusterId += 1
+    labels[i] = clusterId
+    const queue = [...seeds]
+    while (queue.length > 0) {
+      const j = queue.shift()!
+      if (labels[j] === 0) labels[j] = clusterId
+      if (labels[j] !== -1) continue
+      labels[j] = clusterId
+      const more = neighbors(j)
+      if (more.length + 1 >= opts.minPoints) {
+        for (const k of more) if (labels[k] === -1 || labels[k] === 0) queue.push(k)
+      }
+    }
+  }
+
+  const clusters: string[][] = []
+  const noise: string[] = []
+  for (let i = 0; i < n; i++) {
+    if (labels[i] <= 0) {
+      noise.push(points[i].id)
+      continue
+    }
+    const idx = labels[i] - 1
+    if (!clusters[idx]) clusters[idx] = []
+    clusters[idx].push(points[i].id)
+  }
+  return { clusters: clusters.filter(Boolean), noise }
+}

--- a/apps/api/src/lib/synthesis/embedding.ts
+++ b/apps/api/src/lib/synthesis/embedding.ts
@@ -1,0 +1,58 @@
+// Embedding provider. Supports OpenAI-compatible endpoints (OpenAI, Ollama
+// via `ollama serve --openai`, or any compatible gateway). Falls back to a
+// deterministic hash-based stub when no provider is configured so the
+// feature still runs end-to-end in local dev without API keys.
+
+import crypto from 'node:crypto'
+
+const MODEL = process.env.EMBEDDING_MODEL || 'text-embedding-3-small'
+const BASE_URL = process.env.EMBEDDING_BASE_URL || 'https://api.openai.com/v1'
+const API_KEY = process.env.EMBEDDING_API_KEY
+
+export interface EmbeddingResult {
+  model: string
+  vector: number[]
+}
+
+export function hashContent(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex')
+}
+
+export async function embed(text: string): Promise<EmbeddingResult> {
+  if (!API_KEY) return { model: `stub:${MODEL}`, vector: stubEmbedding(text) }
+
+  const res = await fetch(`${BASE_URL}/embeddings`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({ model: MODEL, input: text.slice(0, 8000) }),
+  })
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '')
+    throw new Error(`embedding request failed: ${res.status} ${msg}`)
+  }
+  const data = (await res.json()) as { data: { embedding: number[] }[] }
+  return { model: MODEL, vector: data.data[0].embedding }
+}
+
+// Deterministic 128-dim stub: hashed-trigram bag-of-words. Only used when
+// no API key is configured. Produces stable, content-dependent vectors so
+// that clustering still behaves meaningfully during local testing.
+const STUB_DIM = 128
+
+function stubEmbedding(text: string): number[] {
+  const vec = new Array<number>(STUB_DIM).fill(0)
+  const tokens = text.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean)
+  for (let i = 0; i < tokens.length; i++) {
+    const gram = tokens.slice(i, i + 3).join(' ')
+    if (!gram) continue
+    const h = crypto.createHash('md5').update(gram).digest()
+    const idx = h.readUInt32BE(0) % STUB_DIM
+    const sign = (h[4] & 1) === 0 ? 1 : -1
+    vec[idx] += sign
+  }
+  const norm = Math.sqrt(vec.reduce((acc, v) => acc + v * v, 0)) || 1
+  return vec.map((v) => v / norm)
+}

--- a/apps/api/src/lib/synthesis/embedding.ts
+++ b/apps/api/src/lib/synthesis/embedding.ts
@@ -37,21 +37,31 @@ export async function embed(text: string): Promise<EmbeddingResult> {
   return { model: MODEL, vector: data.data[0].embedding }
 }
 
-// Deterministic 128-dim stub: hashed-trigram bag-of-words. Only used when
-// no API key is configured. Produces stable, content-dependent vectors so
-// that clustering still behaves meaningfully during local testing.
-const STUB_DIM = 128
+// Deterministic hashed bag-of-words stub. Only used when no API key is
+// configured. Counts unigrams (non-stopword) into hashed buckets, so two
+// documents about the same topic share vector mass in overlapping buckets
+// and produce a low cosine distance — enough for clustering to behave
+// meaningfully in local testing.
+const STUB_DIM = 256
+const STUB_STOPWORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'if', 'of', 'in', 'on', 'to', 'for',
+  'with', 'as', 'is', 'are', 'was', 'were', 'be', 'been', 'being', 'by', 'at',
+  'this', 'that', 'these', 'those', 'it', 'its', 'we', 'our', 'you', 'your',
+  'they', 'their', 'them', 'he', 'she', 'his', 'her', 'from', 'into', 'per',
+  'not', 'no', 'so', 'do', 'does', 'did', 'have', 'has', 'had', 'can', 'will',
+  'would', 'should', 'may', 'might', 'one', 'two', 'three',
+])
 
 function stubEmbedding(text: string): number[] {
   const vec = new Array<number>(STUB_DIM).fill(0)
-  const tokens = text.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean)
-  for (let i = 0; i < tokens.length; i++) {
-    const gram = tokens.slice(i, i + 3).join(' ')
-    if (!gram) continue
-    const h = crypto.createHash('md5').update(gram).digest()
-    const idx = h.readUInt32BE(0) % STUB_DIM
-    const sign = (h[4] & 1) === 0 ? 1 : -1
-    vec[idx] += sign
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 2 && !STUB_STOPWORDS.has(t))
+  for (const token of tokens) {
+    const h = crypto.createHash('md5').update(token).digest()
+    vec[h.readUInt32BE(0) % STUB_DIM] += 1
   }
   const norm = Math.sqrt(vec.reduce((acc, v) => acc + v * v, 0)) || 1
   return vec.map((v) => v / norm)

--- a/apps/api/src/lib/synthesis/llm.ts
+++ b/apps/api/src/lib/synthesis/llm.ts
@@ -1,0 +1,104 @@
+// Synthesis LLM call. OpenAI-compatible chat completion. When no API key is
+// configured, falls back to an extractive heuristic so the full pipeline
+// still produces output in local dev.
+
+const MODEL = process.env.SYNTHESIS_MODEL || 'gpt-4o-mini'
+const BASE_URL = process.env.SYNTHESIS_BASE_URL || 'https://api.openai.com/v1'
+const API_KEY = process.env.SYNTHESIS_API_KEY || process.env.EMBEDDING_API_KEY
+
+export interface SynthesisDraft {
+  title: string
+  summary: string
+  contradictions: string
+  openQuestions: string
+}
+
+export interface SynthesisInput {
+  id: string
+  title: string
+  text: string
+}
+
+export async function synthesize(notes: SynthesisInput[]): Promise<SynthesisDraft> {
+  if (!API_KEY) return extractiveFallback(notes)
+
+  const prompt = buildPrompt(notes)
+  const res = await fetch(`${BASE_URL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      temperature: 0.2,
+      response_format: { type: 'json_object' },
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You synthesize clusters of related notes. Ground every claim in a direct quote. Reply as JSON with keys: title, summary, contradictions, openQuestions.',
+        },
+        { role: 'user', content: prompt },
+      ],
+    }),
+  })
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '')
+    throw new Error(`synthesis request failed: ${res.status} ${msg}`)
+  }
+  const data = (await res.json()) as { choices: { message: { content: string } }[] }
+  const raw = data.choices[0]?.message?.content ?? '{}'
+  return parseDraft(raw, notes)
+}
+
+function buildPrompt(notes: SynthesisInput[]): string {
+  const body = notes
+    .map((n, i) => `Note ${i + 1} — "${n.title}" (id=${n.id}):\n${n.text.slice(0, 2000)}`)
+    .join('\n\n---\n\n')
+  return [
+    'Cluster of related notes:',
+    body,
+    '',
+    'Produce:',
+    '- title: a 6-10 word label for the cluster theme',
+    '- summary: 3-6 sentences of shared threads, each claim followed by a direct quote in "quotes"',
+    '- contradictions: explicit disagreements between notes, or "None"',
+    '- openQuestions: unresolved questions raised by the cluster, or "None"',
+  ].join('\n')
+}
+
+function parseDraft(raw: string, notes: SynthesisInput[]): SynthesisDraft {
+  try {
+    const obj = JSON.parse(raw) as Partial<SynthesisDraft>
+    return {
+      title: obj.title?.trim() || defaultTitle(notes),
+      summary: obj.summary?.trim() || '',
+      contradictions: obj.contradictions?.trim() || 'None',
+      openQuestions: obj.openQuestions?.trim() || 'None',
+    }
+  } catch {
+    return extractiveFallback(notes)
+  }
+}
+
+function extractiveFallback(notes: SynthesisInput[]): SynthesisDraft {
+  const summary = notes
+    .map((n) => {
+      const firstSentence = n.text.split(/(?<=[.!?])\s+/)[0]?.slice(0, 200) ?? ''
+      return `"${firstSentence}" — ${n.title}`
+    })
+    .join(' ')
+  return {
+    title: defaultTitle(notes),
+    summary: summary || 'No content available.',
+    contradictions: 'None (auto-generated without LLM)',
+    openQuestions: 'None (auto-generated without LLM)',
+  }
+}
+
+function defaultTitle(notes: SynthesisInput[]): string {
+  const titles = notes.map((n) => n.title).filter(Boolean)
+  if (titles.length === 0) return 'Untitled cluster'
+  return `Cluster: ${titles.slice(0, 2).join(' + ')}${titles.length > 2 ? ` +${titles.length - 2}` : ''}`
+}

--- a/apps/api/src/lib/synthesis/pipeline.ts
+++ b/apps/api/src/lib/synthesis/pipeline.ts
@@ -1,0 +1,141 @@
+// End-to-end orchestration: embed pages (incremental), cluster, and
+// generate synthesis drafts per cluster. Each stage is separate so
+// routes can invoke just the piece they need.
+
+import crypto from 'node:crypto'
+import { prisma } from '../prisma.js'
+import { extractPlainText } from './text.js'
+import { embed, hashContent } from './embedding.js'
+import { dbscan } from './cluster.js'
+import { synthesize, type SynthesisInput } from './llm.js'
+
+const DEFAULT_EPS = 0.35
+const DEFAULT_MIN_POINTS = 3
+
+export interface EmbedReport {
+  total: number
+  embedded: number
+  skipped: number
+}
+
+export async function embedSpace(spaceId: string): Promise<EmbedReport> {
+  const pages = await prisma.page.findMany({
+    where: { spaceId },
+    select: { id: true, title: true, content: true, embedding: true },
+  })
+  let embedded = 0
+  let skipped = 0
+  for (const page of pages) {
+    const text = `${page.title}\n\n${extractPlainText(page.content)}`.trim()
+    if (!text) {
+      skipped += 1
+      continue
+    }
+    const hash = hashContent(text)
+    if (page.embedding && page.embedding.contentHash === hash) {
+      skipped += 1
+      continue
+    }
+    const { model, vector } = await embed(text)
+    await prisma.pageEmbedding.upsert({
+      where: { pageId: page.id },
+      create: { pageId: page.id, model, contentHash: hash, vector },
+      update: { model, contentHash: hash, vector },
+    })
+    embedded += 1
+  }
+  return { total: pages.length, embedded, skipped }
+}
+
+export interface GenerateOptions {
+  eps?: number
+  minPoints?: number
+}
+
+export interface GenerateReport {
+  pagesConsidered: number
+  clusters: number
+  syntheses: number
+  skippedExisting: number
+}
+
+export async function generateSyntheses(
+  spaceId: string,
+  opts: GenerateOptions = {},
+): Promise<GenerateReport> {
+  const eps = opts.eps ?? DEFAULT_EPS
+  const minPoints = opts.minPoints ?? DEFAULT_MIN_POINTS
+
+  const embeddings = await prisma.pageEmbedding.findMany({
+    where: { page: { spaceId } },
+    select: {
+      pageId: true,
+      vector: true,
+      page: { select: { id: true, title: true, content: true } },
+    },
+  })
+  if (embeddings.length < minPoints) {
+    return { pagesConsidered: embeddings.length, clusters: 0, syntheses: 0, skippedExisting: 0 }
+  }
+
+  const { clusters } = dbscan(
+    embeddings.map((e) => ({ id: e.pageId, vector: e.vector })),
+    { eps, minPoints },
+  )
+
+  const existing = await prisma.synthesis.findMany({
+    where: { spaceId },
+    select: { clusterKey: true },
+  })
+  const existingKeys = new Set(existing.map((s) => s.clusterKey))
+
+  const byId = new Map(embeddings.map((e) => [e.pageId, e.page]))
+  let created = 0
+  let skippedExisting = 0
+  for (const pageIds of clusters) {
+    const key = clusterKey(pageIds)
+    if (existingKeys.has(key)) {
+      skippedExisting += 1
+      continue
+    }
+    const notes: SynthesisInput[] = pageIds
+      .map((id) => {
+        const p = byId.get(id)
+        if (!p) return null
+        return { id: p.id, title: p.title, text: extractPlainText(p.content) }
+      })
+      .filter((n): n is SynthesisInput => n !== null)
+    if (notes.length < minPoints) continue
+
+    const draft = await synthesize(notes)
+    await prisma.synthesis.create({
+      data: {
+        spaceId,
+        title: draft.title,
+        summary: draft.summary,
+        contradictions: draft.contradictions,
+        openQuestions: draft.openQuestions,
+        clusterKey: key,
+        sources: {
+          create: notes.map((n) => ({
+            pageId: n.id,
+            snippet: n.text.slice(0, 240),
+          })),
+        },
+      },
+    })
+    created += 1
+  }
+
+  return {
+    pagesConsidered: embeddings.length,
+    clusters: clusters.length,
+    syntheses: created,
+    skippedExisting,
+  }
+}
+
+function clusterKey(pageIds: string[]): string {
+  const sorted = [...pageIds].sort()
+  return crypto.createHash('sha256').update(sorted.join('|')).digest('hex').slice(0, 32)
+}

--- a/apps/api/src/lib/synthesis/pipeline.ts
+++ b/apps/api/src/lib/synthesis/pipeline.ts
@@ -9,7 +9,7 @@ import { embed, hashContent } from './embedding.js'
 import { dbscan } from './cluster.js'
 import { synthesize, type SynthesisInput } from './llm.js'
 
-const DEFAULT_EPS = 0.35
+const DEFAULT_EPS = 0.55
 const DEFAULT_MIN_POINTS = 3
 
 export interface EmbedReport {

--- a/apps/api/src/lib/synthesis/text.ts
+++ b/apps/api/src/lib/synthesis/text.ts
@@ -1,0 +1,45 @@
+// Extract plain text from a Lexical editor JSON tree.
+// Walks the node tree and concatenates any `text` fields, inserting newlines
+// for block-level boundaries so clustering/embeddings see document structure.
+
+type LexicalNode = {
+  type?: string
+  text?: string
+  children?: LexicalNode[]
+}
+
+const BLOCK_TYPES = new Set([
+  'paragraph',
+  'heading',
+  'quote',
+  'listitem',
+  'list',
+  'code',
+  'table',
+  'tablerow',
+  'tablecell',
+  'landmark',
+  'collapsible-container',
+])
+
+export function extractPlainText(content: unknown): string {
+  if (!content || typeof content !== 'object') return ''
+  const root = (content as { root?: LexicalNode }).root
+  if (!root) return ''
+  const parts: string[] = []
+  walk(root, parts)
+  return parts.join('').replace(/\n{3,}/g, '\n\n').trim()
+}
+
+function walk(node: LexicalNode, out: string[]): void {
+  if (typeof node.text === 'string') {
+    out.push(node.text)
+    return
+  }
+  if (node.children) {
+    for (const child of node.children) walk(child, out)
+  }
+  if (node.type && BLOCK_TYPES.has(node.type)) {
+    out.push('\n')
+  }
+}

--- a/apps/api/src/routes/syntheses.ts
+++ b/apps/api/src/routes/syntheses.ts
@@ -1,0 +1,96 @@
+import type { FastifyPluginAsync } from 'fastify'
+import type { Static } from '@sinclair/typebox'
+import { prisma } from '../lib/prisma.js'
+import { embedSpace, generateSyntheses } from '../lib/synthesis/pipeline.js'
+import {
+  GenerateBody,
+  ListSynthesesQuery,
+  SynthesisIdParam,
+  SynthesisSpaceParam,
+  UpdateSynthesisBody,
+} from '../schemas/synthesis.js'
+
+export const synthesisRoutes: FastifyPluginAsync = async (app) => {
+  app.post<{ Params: Static<typeof SynthesisSpaceParam> }>(
+    '/spaces/:spaceId/syntheses/embed',
+    { schema: { params: SynthesisSpaceParam } },
+    async (request) => embedSpace(request.params.spaceId),
+  )
+
+  app.post<{
+    Params: Static<typeof SynthesisSpaceParam>
+    Body: Static<typeof GenerateBody>
+  }>(
+    '/spaces/:spaceId/syntheses/generate',
+    { schema: { params: SynthesisSpaceParam, body: GenerateBody } },
+    async (request) => {
+      await embedSpace(request.params.spaceId)
+      return generateSyntheses(request.params.spaceId, request.body)
+    },
+  )
+
+  app.get<{ Querystring: Static<typeof ListSynthesesQuery> }>(
+    '/syntheses',
+    { schema: { querystring: ListSynthesesQuery } },
+    async (request) => {
+      const { spaceId, status } = request.query
+      return prisma.synthesis.findMany({
+        where: { spaceId, ...(status ? { status } : {}) },
+        orderBy: { createdAt: 'desc' },
+        include: {
+          sources: {
+            include: { page: { select: { id: true, title: true, spaceId: true } } },
+          },
+        },
+      })
+    },
+  )
+
+  app.get<{ Params: Static<typeof SynthesisIdParam> }>(
+    '/syntheses/:id',
+    { schema: { params: SynthesisIdParam } },
+    async (request, reply) => {
+      const synthesis = await prisma.synthesis.findUnique({
+        where: { id: request.params.id },
+        include: {
+          sources: {
+            include: { page: { select: { id: true, title: true, spaceId: true } } },
+          },
+        },
+      })
+      if (!synthesis) return reply.status(404).send({ error: 'Synthesis not found' })
+      return synthesis
+    },
+  )
+
+  app.patch<{
+    Params: Static<typeof SynthesisIdParam>
+    Body: Static<typeof UpdateSynthesisBody>
+  }>(
+    '/syntheses/:id',
+    { schema: { params: SynthesisIdParam, body: UpdateSynthesisBody } },
+    async (request, reply) => {
+      try {
+        return await prisma.synthesis.update({
+          where: { id: request.params.id },
+          data: request.body,
+        })
+      } catch {
+        return reply.status(404).send({ error: 'Synthesis not found' })
+      }
+    },
+  )
+
+  app.delete<{ Params: Static<typeof SynthesisIdParam> }>(
+    '/syntheses/:id',
+    { schema: { params: SynthesisIdParam } },
+    async (request, reply) => {
+      try {
+        await prisma.synthesis.delete({ where: { id: request.params.id } })
+        return { success: true }
+      } catch {
+        return reply.status(404).send({ error: 'Synthesis not found' })
+      }
+    },
+  )
+}

--- a/apps/api/src/schemas/synthesis.ts
+++ b/apps/api/src/schemas/synthesis.ts
@@ -1,0 +1,41 @@
+import { Type } from '@sinclair/typebox'
+
+export const SynthesisSpaceParam = Type.Object({
+  spaceId: Type.String(),
+})
+
+export const SynthesisIdParam = Type.Object({
+  id: Type.String(),
+})
+
+export const GenerateBody = Type.Object({
+  eps: Type.Optional(Type.Number({ minimum: 0, maximum: 2 })),
+  minPoints: Type.Optional(Type.Integer({ minimum: 2, maximum: 50 })),
+})
+
+export const UpdateSynthesisBody = Type.Object({
+  title: Type.Optional(Type.String({ minLength: 1, maxLength: 500 })),
+  summary: Type.Optional(Type.String()),
+  contradictions: Type.Optional(Type.String()),
+  openQuestions: Type.Optional(Type.String()),
+  status: Type.Optional(
+    Type.Union([
+      Type.Literal('PENDING'),
+      Type.Literal('ACCEPTED'),
+      Type.Literal('REJECTED'),
+      Type.Literal('EDITED'),
+    ]),
+  ),
+})
+
+export const ListSynthesesQuery = Type.Object({
+  spaceId: Type.String(),
+  status: Type.Optional(
+    Type.Union([
+      Type.Literal('PENDING'),
+      Type.Literal('ACCEPTED'),
+      Type.Literal('REJECTED'),
+      Type.Literal('EDITED'),
+    ]),
+  ),
+})

--- a/apps/web/src/app/api/spaces/[id]/syntheses/embed/route.ts
+++ b/apps/web/src/app/api/spaces/[id]/syntheses/embed/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { API_BASE_URL } from '@/lib/config'
+
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const res = await fetch(`${API_BASE_URL}/spaces/${id}/syntheses/embed`, { method: 'POST' })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/apps/web/src/app/api/spaces/[id]/syntheses/generate/route.ts
+++ b/apps/web/src/app/api/spaces/[id]/syntheses/generate/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { API_BASE_URL } from '@/lib/config'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const body = await request.json().catch(() => ({}))
+  const res = await fetch(`${API_BASE_URL}/spaces/${id}/syntheses/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/apps/web/src/app/api/syntheses/[id]/route.ts
+++ b/apps/web/src/app/api/syntheses/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { API_BASE_URL } from '@/lib/config'
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const res = await fetch(`${API_BASE_URL}/syntheses/${id}`)
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const body = await request.json()
+  const res = await fetch(`${API_BASE_URL}/syntheses/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const res = await fetch(`${API_BASE_URL}/syntheses/${id}`, { method: 'DELETE' })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/apps/web/src/app/api/syntheses/route.ts
+++ b/apps/web/src/app/api/syntheses/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { API_BASE_URL } from '@/lib/config'
+
+export async function GET(request: NextRequest) {
+  const qs = request.nextUrl.searchParams.toString()
+  const res = await fetch(`${API_BASE_URL}/syntheses${qs ? `?${qs}` : ''}`)
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { BookOpen } from 'lucide-react'
+import { BookOpen, Sparkles } from 'lucide-react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { AppSidebar } from '@/components/layout/AppSidebar'
 import { SearchInput } from '@/components/layout/SearchInput'
@@ -18,10 +18,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <TooltipProvider delayDuration={300}>
           <nav className="bg-white border-b border-gray-200 px-6 py-3 sticky top-0 z-40">
             <div className="flex items-center justify-between">
-              <Link href="/spaces" className="flex items-center gap-2 font-bold text-lg">
-                <BookOpen className="h-5 w-5" />
-                Knowledge Base
-              </Link>
+              <div className="flex items-center gap-6">
+                <Link href="/spaces" className="flex items-center gap-2 font-bold text-lg">
+                  <BookOpen className="h-5 w-5" />
+                  Knowledge Base
+                </Link>
+                <Link
+                  href="/syntheses"
+                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  <Sparkles className="h-4 w-4" />
+                  Syntheses
+                </Link>
+              </div>
               <SearchInput />
             </div>
           </nav>

--- a/apps/web/src/app/syntheses/page.tsx
+++ b/apps/web/src/app/syntheses/page.tsx
@@ -1,0 +1,24 @@
+import { api } from '@/lib/api'
+import { SynthesesPanel } from '@/components/syntheses/SynthesesPanel'
+
+export const dynamic = 'force-dynamic'
+
+export default async function SynthesesPage() {
+  const spaces = await api.spaces.list()
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Syntheses</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          Automatically generated summaries of clusters of related notes.
+        </p>
+      </div>
+      {spaces.length === 0 ? (
+        <p className="text-muted-foreground text-sm">Create a space first to generate syntheses.</p>
+      ) : (
+        <SynthesesPanel spaces={spaces} />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/syntheses/SynthesesPanel.tsx
+++ b/apps/web/src/components/syntheses/SynthesesPanel.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import Link from 'next/link'
+import { Sparkles, RefreshCw, Check, X, FileText } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { api } from '@/lib/api'
+import type { Space, Synthesis, SynthesisStatus, GenerateReport } from '@/lib/types'
+
+const STATUS_VARIANT: Record<SynthesisStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  PENDING: 'secondary',
+  ACCEPTED: 'default',
+  EDITED: 'default',
+  REJECTED: 'destructive',
+}
+
+export function SynthesesPanel({ spaces }: { spaces: Space[] }) {
+  const [selectedSpaceId, setSelectedSpaceId] = useState<string>(spaces[0]?.id ?? '')
+  const [syntheses, setSyntheses] = useState<Synthesis[]>([])
+  const [loading, setLoading] = useState(false)
+  const [generating, setGenerating] = useState(false)
+  const [lastReport, setLastReport] = useState<GenerateReport | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async (spaceId: string) => {
+    if (!spaceId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await api.syntheses.list(spaceId)
+      setSyntheses(list)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh(selectedSpaceId)
+  }, [selectedSpaceId, refresh])
+
+  const handleGenerate = async () => {
+    if (!selectedSpaceId) return
+    setGenerating(true)
+    setError(null)
+    try {
+      const report = await api.syntheses.generate(selectedSpaceId)
+      setLastReport(report)
+      await refresh(selectedSpaceId)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to generate')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const updateStatus = async (id: string, status: SynthesisStatus) => {
+    try {
+      const updated = await api.syntheses.update(id, { status })
+      setSyntheses((prev) => prev.map((s) => (s.id === id ? { ...s, status: updated.status } : s)))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <label htmlFor="space-select" className="text-sm text-muted-foreground">
+            Space
+          </label>
+          <select
+            id="space-select"
+            value={selectedSpaceId}
+            onChange={(e) => setSelectedSpaceId(e.target.value)}
+            className="border rounded-md px-2 py-1.5 text-sm bg-white"
+          >
+            {spaces.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => refresh(selectedSpaceId)} disabled={loading}>
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Button size="sm" onClick={handleGenerate} disabled={generating || !selectedSpaceId}>
+            <Sparkles className={`h-4 w-4 ${generating ? 'animate-pulse' : ''}`} />
+            {generating ? 'Generating…' : 'Generate'}
+          </Button>
+        </div>
+      </div>
+
+      {lastReport && (
+        <div className="text-xs text-muted-foreground">
+          Considered {lastReport.pagesConsidered} pages · {lastReport.clusters} clusters ·{' '}
+          {lastReport.syntheses} new syntheses
+          {lastReport.skippedExisting > 0 ? ` · ${lastReport.skippedExisting} existing` : ''}
+        </div>
+      )}
+
+      {error && (
+        <div className="text-sm text-destructive border border-destructive/30 bg-destructive/5 rounded-md px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      {loading && syntheses.length === 0 ? (
+        <div className="space-y-3">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : syntheses.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground border rounded-lg bg-white">
+          <Sparkles className="h-10 w-10 mx-auto mb-3 opacity-50" />
+          <p className="text-sm">No syntheses yet.</p>
+          <p className="text-xs mt-1">Click Generate to cluster notes and synthesize them.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {syntheses.map((s) => (
+            <SynthesisCard key={s.id} synthesis={s} onStatus={updateStatus} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SynthesisCard({
+  synthesis,
+  onStatus,
+}: {
+  synthesis: Synthesis
+  onStatus: (id: string, status: SynthesisStatus) => void
+}) {
+  return (
+    <Card className={synthesis.status === 'REJECTED' ? 'opacity-60' : undefined}>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base leading-tight">{synthesis.title}</CardTitle>
+          <Badge variant={STATUS_VARIANT[synthesis.status]} className="text-xs shrink-0">
+            {synthesis.status.toLowerCase()}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <Section label="Summary" body={synthesis.summary} />
+        <Section label="Contradictions" body={synthesis.contradictions} />
+        <Section label="Open questions" body={synthesis.openQuestions} />
+
+        <div>
+          <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+            Sources ({synthesis.sources.length})
+          </div>
+          <ul className="space-y-1">
+            {synthesis.sources.map((src) => (
+              <li key={src.pageId}>
+                <Link
+                  href={`/pages/${src.pageId}`}
+                  className="flex items-center gap-2 hover:underline text-sm"
+                >
+                  <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  <span className="truncate">{src.page.title}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex items-center gap-2 pt-2 border-t">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onStatus(synthesis.id, 'ACCEPTED')}
+            disabled={synthesis.status === 'ACCEPTED'}
+          >
+            <Check className="h-4 w-4" /> Accept
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onStatus(synthesis.id, 'REJECTED')}
+            disabled={synthesis.status === 'REJECTED'}
+          >
+            <X className="h-4 w-4" /> Reject
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function Section({ label, body }: { label: string; body: string }) {
+  return (
+    <div>
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+        {label}
+      </div>
+      <p className="whitespace-pre-wrap leading-relaxed">{body}</p>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Space, SpaceWithPages, PageSummary, Page, PageVersion, PageVersionSummary, PageTemplate, CreateSpaceInput, UpdatePageInput, SearchResult } from './types'
+import type { Space, SpaceWithPages, PageSummary, Page, PageVersion, PageVersionSummary, PageTemplate, CreateSpaceInput, UpdatePageInput, SearchResult, Synthesis, SynthesisStatus, EmbedReport, GenerateReport, UpdateSynthesisInput } from './types'
 
 const BASE_URL = typeof window === 'undefined'
   ? (process.env.API_URL || 'http://localhost:3001') + '/api'
@@ -51,5 +51,24 @@ export const api = {
     request<SearchResult[]>(`/search?q=${encodeURIComponent(query)}`),
   templates: {
     list: () => request<PageTemplate[]>('/templates'),
+  },
+  syntheses: {
+    list: (spaceId: string, status?: SynthesisStatus) => {
+      const qs = new URLSearchParams({ spaceId })
+      if (status) qs.set('status', status)
+      return request<Synthesis[]>(`/syntheses?${qs.toString()}`)
+    },
+    get: (id: string) => request<Synthesis>(`/syntheses/${id}`),
+    update: (id: string, data: UpdateSynthesisInput) =>
+      request<Synthesis>(`/syntheses/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+    delete: (id: string) =>
+      request<{ success: boolean }>(`/syntheses/${id}`, { method: 'DELETE' }),
+    embed: (spaceId: string) =>
+      request<EmbedReport>(`/spaces/${spaceId}/syntheses/embed`, { method: 'POST' }),
+    generate: (spaceId: string, opts?: { eps?: number; minPoints?: number }) =>
+      request<GenerateReport>(`/spaces/${spaceId}/syntheses/generate`, {
+        method: 'POST',
+        body: JSON.stringify(opts ?? {}),
+      }),
   },
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -78,3 +78,47 @@ export interface SearchResult {
   createdAt: string
   updatedAt: string
 }
+
+export type SynthesisStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'EDITED'
+
+export interface SynthesisSource {
+  synthesisId: string
+  pageId: string
+  snippet: string | null
+  page: { id: string; title: string; spaceId: string }
+}
+
+export interface Synthesis {
+  id: string
+  spaceId: string
+  title: string
+  summary: string
+  contradictions: string
+  openQuestions: string
+  clusterKey: string
+  status: SynthesisStatus
+  sources: SynthesisSource[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface EmbedReport {
+  total: number
+  embedded: number
+  skipped: number
+}
+
+export interface GenerateReport {
+  pagesConsidered: number
+  clusters: number
+  syntheses: number
+  skippedExisting: number
+}
+
+export interface UpdateSynthesisInput {
+  title?: string
+  summary?: string
+  contradictions?: string
+  openQuestions?: string
+  status?: SynthesisStatus
+}


### PR DESCRIPTION
Closes #12.

## Summary
- Adds end-to-end pipeline for auto-identifying clusters of semantically related pages within a space and synthesizing a note per cluster (summary + contradictions + open questions + linked sources).
- Backend: Prisma `PageEmbedding` / `Synthesis` / `SynthesisSource` models, incremental embedding via content-hash, cosine-distance DBSCAN clustering, OpenAI-compatible embedding + chat providers, idempotent generation by cluster key.
- Frontend: `/syntheses` page with per-space selector, Generate / Refresh actions, and per-card Accept / Reject controls. Top-nav entry added.

## Scope vs. the issue
MVP in this PR covers: embed → cluster → synthesize → surface → user control (accept/reject). Explicit deferrals:
- **Freshness**: on-demand only (generation is idempotent, so re-running is safe)
- **Notifications**: not yet — the page is the only surface
- **Edit in place**: PATCH endpoint exists; inline UI editing is deferred

## Configuration
Both providers are OpenAI-compatible (OpenAI, Ollama via `ollama serve --openai`, any gateway). With no key set, a deterministic hash-based stub embedder and an extractive fallback synthesizer run so the full pipeline still works in local dev.

```
EMBEDDING_BASE_URL=https://api.openai.com/v1   # or http://localhost:11434/v1
EMBEDDING_MODEL=text-embedding-3-small
EMBEDDING_API_KEY=...
SYNTHESIS_BASE_URL=https://api.openai.com/v1
SYNTHESIS_MODEL=gpt-4o-mini
SYNTHESIS_API_KEY=...                          # falls back to EMBEDDING_API_KEY
```

## Test plan
- [ ] `cd apps/api && npx prisma migrate deploy` (or `db push`) to apply `20260422000000_add_syntheses`
- [ ] `npm run dev:api` + `npm run dev:web`
- [ ] Create ≥ 3 pages in a space that share a topic
- [ ] Visit `/syntheses`, pick the space, click **Generate**
- [ ] Confirm report shows `pagesConsidered / clusters / syntheses`
- [ ] Confirm each card lists its source pages (links navigate to `/pages/:id`)
- [ ] Click **Accept** / **Reject**, refresh, confirm status persists
- [ ] With a real `EMBEDDING_API_KEY` + `SYNTHESIS_API_KEY`, confirm titles/summaries look coherent and include quotes from source notes
- [ ] Without any API keys, confirm the stub path still produces clusters and extractive summaries (no network calls)
- [ ] Re-run **Generate** on the same space — confirm `skippedExisting` grows and no duplicates are created

## Known follow-ups (not in this PR)
- Unit tests for `cluster.ts` DBSCAN (apps/api has no test runner wired up yet)
- Inline edit UI for accepted syntheses
- Auto re-generation when source notes change
- `eps` / `minPoints` tuning UI