### PR TITLE
feat(web): apply Atelier warm design tokens

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3,26 +3,72 @@
 @import "../../../../packages/editor/src/styles/editor.css";
 
 @theme {
-  --color-background: #ffffff;
-  --color-foreground: #0a0a0a;
-  --color-muted: #f5f5f5;
-  --color-muted-foreground: #737373;
-  --color-border: #e5e5e5;
-  --color-input: #e5e5e5;
-  --color-ring: #0a0a0a;
-  --color-primary: #0a0a0a;
-  --color-primary-foreground: #fafafa;
-  --color-secondary: #f5f5f5;
-  --color-secondary-foreground: #0a0a0a;
-  --color-destructive: #ef4444;
-  --color-destructive-foreground: #fafafa;
-  --color-accent: #f5f5f5;
-  --color-accent-foreground: #0a0a0a;
-  --color-popover: #ffffff;
-  --color-popover-foreground: #0a0a0a;
-  --color-card: #ffffff;
-  --color-card-foreground: #0a0a0a;
-  --radius-sm: 0.25rem;
-  --radius-md: 0.375rem;
-  --radius-lg: 0.5rem;
+  /* Warm paper & ink */
+  --color-background:           oklch(0.985 0.012 78);   /* page bg, cream */
+  --color-foreground:           oklch(0.22  0.020 60);   /* ink */
+  --color-muted:                oklch(0.945 0.020 78);
+  --color-muted-foreground:     oklch(0.55  0.016 62);
+  --color-border:               oklch(0.90  0.018 72);
+  --color-input:                oklch(0.84  0.020 72);
+  --color-ring:                 oklch(0.66  0.14  40);
+
+  /* Primary = ink (matches CTA buttons like "Publish · v7") */
+  --color-primary:              oklch(0.22  0.020 60);
+  --color-primary-foreground:   oklch(0.985 0.012 78);
+
+  /* Secondary = light paper */
+  --color-secondary:            oklch(0.945 0.020 78);
+  --color-secondary-foreground: oklch(0.22  0.020 60);
+
+  /* Destructive */
+  --color-destructive:          oklch(0.52  0.14  25);
+  --color-destructive-foreground: oklch(0.985 0.012 78);
+
+  /* Accent = terracotta (used for pins, mentions background, active nav) */
+  --color-accent:               oklch(0.92  0.05  40);
+  --color-accent-foreground:    oklch(0.36  0.12  40);
+
+  --color-popover:              oklch(0.985 0.012 78);
+  --color-popover-foreground:   oklch(0.22  0.020 60);
+  --color-card:                 oklch(0.985 0.012 78);
+  --color-card-foreground:      oklch(0.22  0.020 60);
+
+  /* Extra semantic tokens we introduce */
+  --color-terracotta:           oklch(0.66  0.14  40);
+  --color-terracotta-soft:      oklch(0.92  0.05  40);
+  --color-terracotta-ink:       oklch(0.36  0.12  40);
+  --color-sage:                 oklch(0.68  0.08  150);
+  --color-sage-soft:            oklch(0.93  0.04  150);
+  --color-sage-ink:             oklch(0.38  0.08  150);
+  --color-plum:                 oklch(0.62  0.12  330);
+  --color-plum-soft:            oklch(0.93  0.04  330);
+  --color-plum-ink:             oklch(0.36  0.10  330);
+
+  --color-paper-2:              oklch(0.965 0.016 78);   /* raised cards */
+  --color-paper-3:              oklch(0.945 0.020 78);   /* resting rows */
+  --color-paper-4:              oklch(0.915 0.024 76);   /* hover */
+  --color-ink-2:                oklch(0.38  0.018 60);   /* secondary text */
+  --color-ink-3:                oklch(0.55  0.016 62);   /* tertiary / icons */
+
+  --radius-sm: 0.5rem;   /* 8px */
+  --radius-md: 0.625rem; /* 10px */
+  --radius-lg: 0.875rem; /* 14px */
+  --radius-xl: 1.125rem; /* 18px */
+
+  --font-sans:  "Inter Tight", ui-sans-serif, system-ui, sans-serif;
+  --font-serif: "Instrument Serif", "Iowan Old Style", Georgia, serif;
+  --font-mono:  "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* Warm shadows (add next to @theme) */
+@layer base {
+  :root {
+    --shadow-xs: 0 1px 2px oklch(0.30 0.03 60 / 0.06);
+    --shadow-sm: 0 1px 2px oklch(0.30 0.03 60 / 0.05), 0 2px 6px oklch(0.30 0.03 60 / 0.04);
+    --shadow-md: 0 2px 4px oklch(0.30 0.03 60 / 0.06), 0 8px 24px oklch(0.30 0.03 60 / 0.06);
+    --shadow-lg: 0 4px 8px oklch(0.30 0.03 60 / 0.08), 0 20px 48px oklch(0.30 0.03 60 / 0.10);
+  }
+  body { font-family: var(--font-sans); font-feature-settings: "ss01","cv11"; }
+  .serif { font-family: var(--font-serif); font-weight: 400; letter-spacing: -0.01em; }
+  .mono { font-family: var(--font-mono); font-feature-settings: "tnum", "zero"; }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,10 +1,19 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { Inter_Tight, Instrument_Serif, JetBrains_Mono } from 'next/font/google'
 import { BookOpen, Sparkles } from 'lucide-react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { AppSidebar } from '@/components/layout/AppSidebar'
 import { SearchInput } from '@/components/layout/SearchInput'
 import './globals.css'
+
+const interTight = Inter_Tight({ subsets: ['latin'], variable: '--font-sans' })
+const instrumentSerif = Instrument_Serif({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-serif',
+})
+const jetMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' })
 
 export const metadata: Metadata = {
   title: 'Knowledge Base',
@@ -14,7 +23,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-50">
+      <body
+        className={`${interTight.variable} ${instrumentSerif.variable} ${jetMono.variable} min-h-screen bg-background text-foreground`}
+      >
         <TooltipProvider delayDuration={300}>
           <nav className="bg-white border-b border-gray-200 px-6 py-3 sticky top-0 z-40">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Replace `apps/web/src/app/globals.css` `@theme` with the warm paper/ink `oklch` palette from the Atelier handoff (terracotta/sage/plum, paper-2/3/4, ink-2/3, updated radii, warm shadows).
- Wire Inter Tight / Instrument Serif / JetBrains Mono via `next/font/google` in the root layout and expose them as CSS variables (`--font-sans`, `--font-serif`, `--font-mono`).
- Switch root `<body>` from `bg-gray-50` to `bg-background text-foreground` so the cream canvas is visible under existing pages.

Scope is section 3 of the handoff README only. Screen-level restyles (Topbar, Sidebar, Page viewer, Right rail, …) follow in subsequent PRs — the handoff is structured so each section lands independently without merge pain.

## Test plan
- [ ] `npm run dev:web` boots without console errors
- [ ] Background across existing routes is cream (`--color-background`)
- [ ] `.serif` / `.mono` utility classes render Instrument Serif / JetBrains Mono
- [ ] Existing pages keep working (no visual regressions beyond expected palette shift)