### PR TITLE
feat(web): add Atelier Topbar for page routes

### DIFF
--- a/apps/web/src/app/pages/[pageId]/edit/page.tsx
+++ b/apps/web/src/app/pages/[pageId]/edit/page.tsx
@@ -1,9 +1,6 @@
-import Link from 'next/link'
-import { Eye } from 'lucide-react'
+import { notFound } from 'next/navigation'
 import { api } from '@/lib/api'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb'
+import { Topbar } from '@/components/layout/Topbar'
 import { PageEditor } from '@/components/pages/PageEditor'
 
 export default async function EditPagePage({
@@ -19,41 +16,15 @@ export default async function EditPagePage({
     page = await api.pages.get(pageId)
     space = await api.spaces.get(page.spaceId)
   } catch {
-    space = null
-    page = null
+    notFound()
   }
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink asChild><Link href="/spaces">Spaces</Link></BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink asChild><Link href={`/spaces/${page?.spaceId ?? ''}`}>{space?.name ?? 'Space'}</Link></BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Editing</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Link href={`/pages/${pageId}`}>
-              <Button variant="outline" size="sm">
-                <Eye className="h-4 w-4" />
-                View
-              </Button>
-            </Link>
-          </TooltipTrigger>
-          <TooltipContent>View published page</TooltipContent>
-        </Tooltip>
+    <div className="-mx-6 -mt-8">
+      <Topbar space={space} page={page} mode="edit" />
+      <div className="px-6 pt-6 pb-8">
+        <PageEditor pageId={pageId} />
       </div>
-      <PageEditor pageId={pageId} />
     </div>
   )
 }

--- a/apps/web/src/app/pages/[pageId]/page.tsx
+++ b/apps/web/src/app/pages/[pageId]/page.tsx
@@ -1,10 +1,6 @@
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { Pencil, History } from 'lucide-react'
 import { api } from '@/lib/api'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb'
+import { Topbar } from '@/components/layout/Topbar'
 import { PageViewer } from '@/components/pages/PageViewer'
 
 export const dynamic = 'force-dynamic'
@@ -25,49 +21,11 @@ export default async function ViewPagePage({
   }
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-4">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink asChild><Link href="/spaces">Spaces</Link></BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink asChild><Link href={`/spaces/${page.spaceId}`}>{space.name}</Link></BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{page.title}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <div className="flex items-center gap-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link href={`/pages/${pageId}/history`}>
-                <Button variant="outline" size="sm">
-                  <History className="h-4 w-4" />
-                  History
-                </Button>
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent>View version history</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link href={`/pages/${pageId}/edit`}>
-                <Button variant="outline" size="sm">
-                  <Pencil className="h-4 w-4" />
-                  Edit
-                </Button>
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent>Edit this page</TooltipContent>
-          </Tooltip>
-        </div>
+    <div className="-mx-6 -mt-8">
+      <Topbar space={space} page={page} mode="read" />
+      <div className="px-6 pt-6 pb-8">
+        <PageViewer page={page} />
       </div>
-      <PageViewer page={page} />
     </div>
   )
 }

--- a/apps/web/src/components/atoms/SpaceGlyph.tsx
+++ b/apps/web/src/components/atoms/SpaceGlyph.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils'
+import type { SpaceType } from '@/lib/types'
+
+const HUE_BY_TYPE: Record<SpaceType | 'DEFAULT', number> = {
+  PERSONAL: 40,
+  TEAM: 150,
+  OFFICIAL: 60,
+  DEFAULT: 330,
+}
+
+const SIZE_CLASSES: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'h-4 w-4 text-[9px]',
+  md: 'h-6 w-6 text-[11px]',
+  lg: 'h-7 w-7 text-[12px]',
+}
+
+interface SpaceGlyphProps {
+  name: string
+  type?: SpaceType
+  size?: keyof typeof SIZE_CLASSES
+  className?: string
+}
+
+export function SpaceGlyph({ name, type, size = 'md', className }: SpaceGlyphProps) {
+  const hue = type ? HUE_BY_TYPE[type] : HUE_BY_TYPE.DEFAULT
+  const initial = name.trim().charAt(0).toUpperCase() || '?'
+  const gradient = `radial-gradient(circle at 30% 30%, oklch(0.88 0.06 ${hue}), oklch(0.58 0.14 ${hue}))`
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'inline-flex items-center justify-center rounded-full font-semibold text-white shadow-xs',
+        SIZE_CLASSES[size],
+        className,
+      )}
+      style={{ backgroundImage: gradient }}
+    >
+      {initial}
+    </span>
+  )
+}

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,0 +1,135 @@
+import Link from 'next/link'
+import {
+  History,
+  Share2,
+  Globe,
+  Eye,
+  Pencil,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { SpaceGlyph } from '@/components/atoms/SpaceGlyph'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import type { Page, Space } from '@/lib/types'
+
+function getInitials(name: string) {
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .filter(Boolean)
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+interface TopbarProps {
+  space: Pick<Space, 'id' | 'name' | 'type'>
+  page: Pick<Page, 'id' | 'title' | 'status' | 'author' | 'publishedVersion'>
+  mode: 'read' | 'edit'
+}
+
+export function Topbar({ space, page, mode }: TopbarProps) {
+  const isPublished = page.status === 'PUBLISHED'
+  const versionLabel = page.publishedVersion ? `v${page.publishedVersion.version}` : null
+
+  return (
+    <header className="h-[52px] px-5 border-b border-border bg-background flex items-center gap-[14px]">
+      <nav
+        aria-label="breadcrumb"
+        className="flex items-center gap-1.5 min-w-0 flex-shrink overflow-hidden text-[13px] text-ink-3"
+      >
+        <Link
+          href={`/spaces/${space.id}`}
+          className="flex items-center gap-1.5 hover:text-foreground transition-colors"
+        >
+          <SpaceGlyph name={space.name} type={space.type} size="sm" />
+          <span>{space.name}</span>
+        </Link>
+        <span aria-hidden="true" className="text-ink-3/60">/</span>
+        <span
+          className="font-medium text-foreground overflow-hidden text-ellipsis whitespace-nowrap min-w-0"
+          title={page.title}
+        >
+          {page.title}
+        </span>
+      </nav>
+
+      <div className="flex-1" />
+
+      <div className="inline-flex items-center rounded-lg bg-paper-3 p-[2px] text-[12.5px]">
+        <Link
+          href={`/pages/${page.id}`}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md px-3 py-1 transition-colors',
+            mode === 'read'
+              ? 'bg-background text-foreground shadow-xs'
+              : 'text-ink-2 hover:text-foreground',
+          )}
+          aria-current={mode === 'read' ? 'page' : undefined}
+        >
+          <Eye className="h-3.5 w-3.5" />
+          Read
+        </Link>
+        <Link
+          href={`/pages/${page.id}/edit`}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md px-3 py-1 transition-colors',
+            mode === 'edit'
+              ? 'bg-background text-foreground shadow-xs'
+              : 'text-ink-2 hover:text-foreground',
+          )}
+          aria-current={mode === 'edit' ? 'page' : undefined}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+          Edit
+        </Link>
+      </div>
+
+      {page.author && (
+        <div className="flex items-center">
+          <Avatar className="h-6 w-6 ring-2 ring-background">
+            <AvatarImage
+              src={`https://api.dicebear.com/9.x/initials/svg?seed=${encodeURIComponent(page.author)}&radius=50&backgroundColor=e8c4a0`}
+              alt={page.author}
+            />
+            <AvatarFallback className="text-[10px]">{getInitials(page.author)}</AvatarFallback>
+          </Avatar>
+        </div>
+      )}
+
+      <Link
+        href={`/pages/${page.id}/history`}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-[11px] py-[5px] text-[12.5px] text-ink-2 hover:text-foreground transition-colors"
+      >
+        <History className="h-3.5 w-3.5" />
+        History
+      </Link>
+
+      <button
+        type="button"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-[11px] py-[5px] text-[12.5px] text-ink-2 hover:text-foreground transition-colors"
+      >
+        <Share2 className="h-3.5 w-3.5" />
+        Share
+      </button>
+
+      {isPublished ? (
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg bg-sage-soft px-[11px] py-[5px] text-[12.5px] font-medium text-sage-ink"
+        >
+          <span aria-hidden="true" className="inline-block h-1.5 w-1.5 rounded-full bg-sage" />
+          Live
+          {versionLabel && <span className="mono text-[11px] opacity-70">· {versionLabel}</span>}
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-foreground px-[11px] py-[5px] text-[12.5px] font-medium text-background hover:opacity-90 transition-opacity"
+        >
+          <Globe className="h-3.5 w-3.5" />
+          Publish
+        </button>
+      )}
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- New `Topbar` component ([`apps/web/src/components/layout/Topbar.tsx`](apps/web/src/components/layout/Topbar.tsx)): 52px bar with breadcrumb (SpaceGlyph → space name → page title, truncating), segmented Read/Edit toggle, author avatar, History/Share outline buttons, and a draft/live Publish button that flips palette (`bg-foreground` when drafting, `bg-sage-soft` when live) — matches handoff §4.3.
- New `SpaceGlyph` atom ([`apps/web/src/components/atoms/SpaceGlyph.tsx`](apps/web/src/components/atoms/SpaceGlyph.tsx)): radial-gradient disc keyed off `SpaceType` (terracotta=PERSONAL, sage=TEAM, ink=OFFICIAL). Reused by sidebar / command palette later.
- Wire Topbar into `/pages/[pageId]` ([view](apps/web/src/app/pages/[pageId]/page.tsx)) and `/pages/[pageId]/edit` ([edit](apps/web/src/app/pages/[pageId]/edit/page.tsx)); remove the ad-hoc breadcrumb+button cluster that used to sit at the top of each route.

Stays inside the current max-w-5xl wrapper by design — widening the main container is a layout concern for the §4.1 App shell PR. History still deep-links to the existing `/history` route until §4.7 turns it into a Sheet. The Publish and Share buttons are visual only this PR; §4.8 brings the real `Dialog`.

## Test plan
- [ ] `/pages/:id` renders the Topbar with Read active, Edit inactive
- [ ] `/pages/:id/edit` renders the Topbar with Edit active, Read inactive
- [ ] Clicking Read / Edit navigates between the two routes
- [ ] Breadcrumb truncates long titles with ellipsis and exposes the full title via `title` attribute
- [ ] History button links to `/pages/:id/history`
- [ ] Draft pages show "Publish" (ink); published pages show "Live" pill with `vN`