### PR TITLE
feat(web): restyle AppSidebar to Atelier look

### DIFF
--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -3,7 +3,18 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { User, Users, Building2, FileText, ChevronRight, Plus, ChevronsUpDown, Check } from 'lucide-react'
+import {
+  ChevronRight,
+  Plus,
+  ChevronsUpDown,
+  Check,
+  Search,
+  Inbox,
+  Sparkles,
+  Clock,
+  Globe,
+  Settings,
+} from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   DropdownMenu,
@@ -11,23 +22,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Skeleton } from '@/components/ui/skeleton'
+import { SpaceGlyph } from '@/components/atoms/SpaceGlyph'
 import { cn } from '@/lib/utils'
 import { api } from '@/lib/api'
-import type { Space, SpaceType, SpaceWithPages, PageSummary } from '@/lib/types'
-
-// ── Space icon by type ──
-
-const SPACE_ICONS: Record<SpaceType, typeof User> = {
-  PERSONAL: User,
-  TEAM: Users,
-  OFFICIAL: Building2,
-}
-
-function SpaceIcon({ type, className }: { type?: SpaceType; className?: string }) {
-  const Icon = SPACE_ICONS[type ?? 'TEAM']
-  return <Icon className={className} />
-}
+import type { Space, SpaceWithPages, PageSummary } from '@/lib/types'
 
 // ── Tree building ──
 
@@ -60,6 +60,7 @@ function buildPageTree(pages: PageSummary[]): PageTreeNode[] {
 interface FlatRow {
   id: string
   title: string
+  status: string
   depth: number
   hasChildren: boolean
   spaceId: string
@@ -86,6 +87,7 @@ function flattenNodes(
     rows.push({
       id: node.id,
       title: node.title,
+      status: node.status,
       depth,
       hasChildren: node.children.length > 0,
       spaceId,
@@ -118,6 +120,7 @@ function collectAncestorIds(
 }
 
 const ROW_HEIGHT = 32
+const EXPANDED_KEY = 'kb:sidebar:expanded'
 
 // ── Component ──
 
@@ -128,7 +131,17 @@ export function AppSidebar() {
   const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(null)
   const [currentSpace, setCurrentSpace] = useState<SpaceWithPages | null>(null)
   const [loading, setLoading] = useState(true)
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
+    if (typeof window === 'undefined') return new Set()
+    try {
+      const raw = window.localStorage.getItem(EXPANDED_KEY)
+      if (!raw) return new Set()
+      const arr = JSON.parse(raw)
+      return new Set(Array.isArray(arr) ? arr : [])
+    } catch {
+      return new Set()
+    }
+  })
   const [creatingFor, setCreatingFor] = useState<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -152,7 +165,6 @@ export function AppSidebar() {
   useEffect(() => {
     if (spaceList.length === 0) return
 
-    // Resolve mySpace slug to actual PERSONAL space ID
     if (currentSpaceId === 'mySpace') {
       const personal = spaceList.find((s) => s.type === 'PERSONAL')
       if (personal) setSelectedSpaceId(personal.id)
@@ -164,13 +176,11 @@ export function AppSidebar() {
       return
     }
 
-    // If viewing a page, find which space it belongs to
     if (currentPageId && currentSpace) {
       const found = currentSpace.pages.find((p) => p.id === currentPageId)
-      if (found) return // already on the right space
+      if (found) return
     }
 
-    // Try to find page in all spaces
     if (currentPageId) {
       Promise.all(spaceList.map((s) => api.spaces.get(s.id))).then((allSpaces) => {
         for (const space of allSpaces) {
@@ -184,25 +194,21 @@ export function AppSidebar() {
     }
   }, [currentSpaceId, currentPageId, spaceList]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Fetch selected space's pages
   useEffect(() => {
     if (!selectedSpaceId) return
     api.spaces.get(selectedSpaceId).then(setCurrentSpace)
   }, [selectedSpaceId])
 
-  // Refresh current space on pathname change
   useEffect(() => {
     if (loading || !selectedSpaceId) return
     api.spaces.get(selectedSpaceId).then(setCurrentSpace)
   }, [pathname]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Refresh space list on pathname change (new spaces may have been created)
   useEffect(() => {
     if (loading) return
     api.spaces.list().then(setSpaceList)
   }, [pathname, loading])
 
-  // Auto-expand ancestor pages of current page
   useEffect(() => {
     if (!currentSpace || !currentPageId) return
     const page = currentSpace.pages.find((p) => p.id === currentPageId)
@@ -217,13 +223,21 @@ export function AppSidebar() {
     }
   }, [currentSpace, currentPageId])
 
-  // Build tree for current space
+  // Persist expandedIds to localStorage
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(EXPANDED_KEY, JSON.stringify([...expandedIds]))
+    } catch {
+      /* ignore */
+    }
+  }, [expandedIds])
+
   const pageTree = useMemo(() => {
     if (!currentSpace) return []
     return buildPageTree(currentSpace.pages)
   }, [currentSpace])
 
-  // Flatten for virtualizer
   const flatRows = useMemo(
     () => (currentSpace ? flattenPages(pageTree, currentSpace.id, expandedIds) : []),
     [pageTree, currentSpace, expandedIds],
@@ -264,46 +278,96 @@ export function AppSidebar() {
     [creatingFor, router],
   )
 
+  const handleAddRootPage = useCallback(async () => {
+    if (!selectedSpaceId || creatingFor) return
+    setCreatingFor(selectedSpaceId)
+    try {
+      const page = await api.pages.create(selectedSpaceId)
+      router.push(`/pages/${page.id}/edit`)
+    } finally {
+      setCreatingFor(null)
+    }
+  }, [selectedSpaceId, creatingFor, router])
+
   const selectedSpace = spaceList.find((s) => s.id === selectedSpaceId)
 
   if (loading) {
     return (
-      <div className="w-60 border-r bg-white p-4 space-y-3">
+      <aside className="w-[268px] flex-shrink-0 flex flex-col border-r border-border bg-gradient-to-b from-[oklch(0.975_0.014_78)] to-[oklch(0.955_0.018_78)] p-4 space-y-3">
         <Skeleton className="h-3 w-16" />
         <Skeleton className="h-5 w-36" />
         <Skeleton className="h-4 w-28 ml-4" />
         <Skeleton className="h-4 w-24 ml-4" />
         <Skeleton className="h-5 w-32" />
-      </div>
+      </aside>
     )
   }
 
   return (
-    <div className="w-60 border-r bg-white flex flex-col shrink-0">
-      {/* Space switcher dropdown */}
-      <div className="px-3 py-3 border-b">
+    <aside className="w-[268px] flex-shrink-0 flex flex-col border-r border-border bg-gradient-to-b from-[oklch(0.975_0.014_78)] to-[oklch(0.955_0.018_78)]">
+      {/* Brand block */}
+      <div className="px-3 pt-3 pb-2 flex items-center gap-2.5">
+        <span
+          aria-hidden="true"
+          className="inline-flex items-center justify-center h-[26px] w-[26px] rounded-lg text-background serif text-[17px] leading-none"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 30% 30%, oklch(0.78 0.10 40), oklch(0.50 0.16 40))',
+          }}
+        >
+          A
+        </span>
+        <span className="flex flex-col leading-tight min-w-0">
+          <span className="serif text-[17px] text-foreground">Atelier</span>
+          <span className="text-[10px] uppercase tracking-[0.08em] text-ink-3">
+            Knowledge base
+          </span>
+        </span>
+      </div>
+
+      {/* Space switcher */}
+      <div className="px-3 pt-1">
         <DropdownMenu>
-          <DropdownMenuTrigger className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-md hover:bg-gray-100 outline-none">
-            <SpaceIcon type={selectedSpace?.type} className="h-4 w-4 text-blue-500 shrink-0" />
-            <span className="truncate flex-1 text-left font-medium">
-              {selectedSpace?.name ?? 'Select space'}
+          <DropdownMenuTrigger className="flex items-center gap-2 w-full bg-background border border-border rounded-[10px] shadow-xs p-2 outline-none hover:bg-paper-2 transition-colors">
+            <SpaceGlyph
+              name={selectedSpace?.name ?? 'Space'}
+              type={selectedSpace?.type}
+              size="md"
+            />
+            <span className="flex-1 min-w-0 text-left">
+              <span className="block text-[13px] font-medium text-foreground truncate">
+                {selectedSpace?.name ?? 'Select space'}
+              </span>
+              <span className="block text-[11px] uppercase tracking-wider text-ink-3">
+                {selectedSpace?.type?.toLowerCase() ?? 'space'}
+              </span>
             </span>
-            <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <ChevronsUpDown className="h-3.5 w-3.5 text-ink-3 shrink-0" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-[var(--radix-dropdown-menu-trigger-width)]">
+          <DropdownMenuContent
+            align="start"
+            className="w-[var(--radix-dropdown-menu-trigger-width)]"
+          >
             {spaceList.map((space) => (
               <DropdownMenuItem
                 key={space.id}
                 onClick={() => {
                   setSelectedSpaceId(space.id)
-                  router.push(space.type === 'PERSONAL' ? '/spaces/mySpace' : `/spaces/${space.id}`)
+                  router.push(
+                    space.type === 'PERSONAL' ? '/spaces/mySpace' : `/spaces/${space.id}`,
+                  )
                 }}
-                className="flex items-center gap-2"
+                className="flex items-center gap-2 py-1.5"
               >
-                <SpaceIcon type={space.type} className="h-4 w-4 text-blue-500 shrink-0" />
-                <span className="truncate flex-1">{space.name}</span>
+                <SpaceGlyph name={space.name} type={space.type} size="md" />
+                <span className="flex-1 min-w-0">
+                  <span className="block text-[13px] font-medium truncate">{space.name}</span>
+                  <span className="block text-[10.5px] uppercase tracking-wider text-ink-3">
+                    {space.type.toLowerCase()}
+                  </span>
+                </span>
                 {space.id === selectedSpaceId && (
-                  <Check className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  <Check className="h-3.5 w-3.5 text-terracotta shrink-0" />
                 )}
               </DropdownMenuItem>
             ))}
@@ -311,18 +375,75 @@ export function AppSidebar() {
         </DropdownMenu>
       </div>
 
+      {/* Quick-find */}
+      <div className="px-3 pt-2">
+        <button
+          type="button"
+          className="flex items-center gap-2 w-full px-3 py-[7px] rounded-lg bg-muted text-ink-3 text-sm hover:bg-paper-3 transition-colors"
+          onClick={() => {
+            // Command palette (§4.9) — stub for now
+            if (typeof window !== 'undefined') {
+              window.dispatchEvent(new CustomEvent('kb:open-palette'))
+            }
+          }}
+        >
+          <Search className="h-3.5 w-3.5 shrink-0" />
+          <span className="flex-1 text-left">Quick find…</span>
+          <kbd className="mono text-[10.5px] text-ink-3 border border-border rounded px-1 py-0.5 bg-background">
+            ⌘K
+          </kbd>
+        </button>
+      </div>
+
+      {/* Nav group */}
+      <nav className="px-3 pt-3 pb-1 flex flex-col gap-0.5">
+        <NavRow href="/inbox" icon={<Inbox className="h-3.5 w-3.5" />} label="Inbox" disabled />
+        <NavRow
+          href="/syntheses"
+          icon={<Sparkles className="h-3.5 w-3.5" />}
+          label="Syntheses"
+          badge="new"
+          active={pathname.startsWith('/syntheses')}
+        />
+        <NavRow href="/recent" icon={<Clock className="h-3.5 w-3.5" />} label="Recent" disabled />
+        <NavRow
+          href="/published"
+          icon={<Globe className="h-3.5 w-3.5" />}
+          label="Published"
+          disabled
+        />
+      </nav>
+
+      {/* Pages section header */}
+      <div className="px-4 pt-4 pb-1 flex items-center justify-between">
+        <span className="text-[10.5px] uppercase tracking-[0.1em] text-ink-3 font-semibold">
+          Pages
+        </span>
+        <button
+          type="button"
+          onClick={handleAddRootPage}
+          disabled={creatingFor === selectedSpaceId}
+          className="inline-flex items-center justify-center h-5 w-5 rounded hover:bg-paper-3 text-ink-3 hover:text-foreground disabled:opacity-50 transition-colors"
+          title="New page"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
       {/* Virtualized page tree */}
       <div ref={scrollRef} className="flex-1 overflow-auto">
         {flatRows.length === 0 ? (
-          <div className="px-4 py-3 text-xs text-muted-foreground">No pages</div>
+          <div className="px-4 py-3 text-xs text-ink-3">No pages</div>
         ) : (
           <div
-            className="relative w-full p-2"
+            className="relative w-full px-2 py-1"
             style={{ height: virtualizer.getTotalSize() }}
           >
             {virtualizer.getVirtualItems().map((virtualItem) => {
               const row = flatRows[virtualItem.index]
               const isExpanded = expandedIds.has(row.id)
+              const isActive = row.id === currentPageId
+              const isDraft = row.status !== 'PUBLISHED'
 
               return (
                 <div
@@ -333,49 +454,56 @@ export function AppSidebar() {
                     transform: `translateY(${virtualItem.start}px)`,
                   }}
                 >
-                  <div className="flex items-center" style={{ paddingLeft: row.depth * 16 }}>
+                  <div
+                    className={cn(
+                      'flex items-center gap-1 mx-1 rounded-[7px] transition-colors',
+                      isActive
+                        ? 'bg-terracotta-soft text-foreground font-semibold'
+                        : 'hover:bg-paper-3',
+                    )}
+                    style={{ paddingLeft: row.depth * 16 + 4 }}
+                  >
                     {row.hasChildren ? (
                       <button
+                        type="button"
                         onClick={() => toggleExpand(row.id)}
-                        className="flex items-center gap-1.5 flex-1 min-w-0 px-2 py-1.5 text-sm rounded-md hover:bg-gray-100"
+                        className="inline-flex items-center justify-center h-5 w-5 shrink-0 text-ink-3 hover:text-foreground"
+                        aria-label={isExpanded ? 'Collapse' : 'Expand'}
                       >
                         <ChevronRight
                           className={cn(
-                            'h-3 w-3 text-muted-foreground transition-transform shrink-0',
+                            'h-3 w-3 transition-transform duration-[140ms]',
                             isExpanded && 'rotate-90',
                           )}
                         />
-                        <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                        <Link
-                          href={`/pages/${row.id}`}
-                          className={cn(
-                            'truncate flex-1 text-left',
-                            row.id === currentPageId && 'font-medium',
-                          )}
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          {row.title}
-                        </Link>
                       </button>
                     ) : (
-                      <Link
-                        href={`/pages/${row.id}`}
-                        className={cn(
-                          'flex items-center gap-1.5 flex-1 min-w-0 px-2 py-1.5 text-sm rounded-md hover:bg-gray-100 truncate',
-                          row.id === currentPageId && 'bg-gray-100 font-medium',
-                        )}
-                      >
-                        <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                        <span className="truncate">{row.title}</span>
-                      </Link>
+                      <span className="inline-block h-5 w-5 shrink-0" />
                     )}
+                    <Link
+                      href={`/pages/${row.id}`}
+                      className={cn(
+                        'flex items-center gap-1.5 flex-1 min-w-0 px-1.5 py-1 text-sm truncate',
+                        !isActive && 'text-ink-2',
+                      )}
+                    >
+                      <span className="truncate">{row.title}</span>
+                      {isDraft && (
+                        <span
+                          aria-hidden="true"
+                          className="inline-block h-[5px] w-[5px] rounded-full bg-ink-3 shrink-0"
+                          title="Draft"
+                        />
+                      )}
+                    </Link>
                     <button
+                      type="button"
                       onClick={(e) => handleAddSubPage(e, row.spaceId, row.id)}
                       disabled={creatingFor === row.id}
-                      className="hidden group-hover:flex items-center justify-center h-5 w-5 rounded hover:bg-gray-200 shrink-0 mr-1"
+                      className="hidden group-hover:inline-flex items-center justify-center h-5 w-5 rounded hover:bg-paper-4 text-ink-3 shrink-0 mr-1"
                       title="Add sub-page"
                     >
-                      <Plus className="h-3 w-3 text-muted-foreground" />
+                      <Plus className="h-3 w-3" />
                     </button>
                   </div>
                 </div>
@@ -384,6 +512,74 @@ export function AppSidebar() {
           </div>
         )}
       </div>
-    </div>
+
+      {/* Footer — user strip */}
+      <div className="border-t border-border bg-[oklch(0.96_0.016_78)] px-3 py-[10px] flex items-center gap-2.5">
+        <div className="relative">
+          <Avatar className="h-7 w-7">
+            <AvatarImage
+              src="https://api.dicebear.com/9.x/initials/svg?seed=You&radius=50&backgroundColor=e8c4a0"
+              alt="You"
+            />
+            <AvatarFallback className="text-[10px]">Y</AvatarFallback>
+          </Avatar>
+          <span
+            aria-hidden="true"
+            className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-sage ring-2 ring-[oklch(0.96_0.016_78)]"
+          />
+        </div>
+        <span className="flex-1 min-w-0 flex flex-col leading-tight">
+          <span className="text-[12.5px] font-medium text-foreground truncate">You</span>
+          <span className="text-[10.5px] text-ink-3">Online</span>
+        </span>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center h-6 w-6 rounded-md text-ink-3 hover:text-foreground hover:bg-paper-3"
+          title="Settings"
+        >
+          <Settings className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </aside>
   )
+}
+
+interface NavRowProps {
+  href: string
+  icon: React.ReactNode
+  label: string
+  badge?: string
+  active?: boolean
+  disabled?: boolean
+}
+
+function NavRow({ href, icon, label, badge, active, disabled }: NavRowProps) {
+  const inner = (
+    <span
+      className={cn(
+        'flex items-center gap-[9px] px-2 py-[5px] rounded-[7px] text-sm transition-colors',
+        active
+          ? 'bg-terracotta-soft text-foreground font-medium'
+          : 'text-ink-2 hover:bg-paper-3',
+        disabled && 'opacity-50 cursor-not-allowed',
+      )}
+    >
+      <span className="text-ink-3">{icon}</span>
+      <span className="flex-1 truncate">{label}</span>
+      {badge && (
+        <span className="inline-flex items-center rounded-full bg-plum-soft text-plum-ink px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide">
+          {badge}
+        </span>
+      )}
+    </span>
+  )
+
+  if (disabled) {
+    return (
+      <span role="link" aria-disabled="true">
+        {inner}
+      </span>
+    )
+  }
+  return <Link href={href}>{inner}</Link>
 }


### PR DESCRIPTION
## Summary
Visual restyle of [`AppSidebar`](apps/web/src/components/layout/AppSidebar.tsx) per handoff §4.2, preserving all state, virtualizer, expansion, and sub-page creation logic.

- **Container**: 268px wide, paper gradient, single hairline `border-r`.
- **Brand block**: terracotta 'A' glyph + serif \"Atelier\" wordmark with uppercase \"Knowledge base\" tagline.
- **Space switcher**: paper card with `SpaceGlyph`, type subline, current-space `Check` tinted terracotta.
- **Quick find**: dispatches a `kb:open-palette` `CustomEvent` — the command palette itself comes in §4.9.
- **Nav group**: Inbox / Syntheses (plum \"new\" badge) / Recent / Published. Syntheses reflects active pathname; the rest are visually present but disabled until routes exist.
- **Pages header**: uppercase label + `Plus` button that creates a root page.
- **Page tree rows**: terracotta-soft active row, paper-3 hover, 5px draft dot, 32px row height, `depth * 16` indent preserved, persisted `expandedIds` in localStorage.
- **Footer user strip**: 28px avatar with sage online dot, name/status, settings button.

Stacked on top of [#23](https://github.com/StanleyLiang/knowledge-management/pull/23) (base: `claude/topbar`) so it rebases cleanly onto main once tokens + topbar merge.

## Deferred
Drag-and-drop reparenting (§4.2) is **not in this PR** — the API's `UpdatePageBody` schema does not accept `parentId` yet. Will ship as a follow-up that covers the schema/type change and the drop indicator together.

## Test plan
- [ ] Sidebar is 268px wide with cream gradient and hairline border
- [ ] Brand block renders the terracotta glyph and Atelier / Knowledge base text
- [ ] Space switcher opens, lists spaces with glyphs, current-space shows a terracotta check
- [ ] Quick find dispatches `kb:open-palette` (verifiable via `window.addEventListener` in devtools)
- [ ] Nav: Inbox/Recent/Published visibly disabled; Syntheses routes to `/syntheses` and marks active
- [ ] Pages section Plus button creates a new root page and navigates to edit
- [ ] Current page row gets terracotta-soft background + bold
- [ ] Draft pages show the trailing 5px dot
- [ ] Chevron expand/collapse persists across reload (localStorage key `kb:sidebar:expanded`)
- [ ] Footer shows avatar with sage online dot and settings icon