### PR TITLE
feat(web): restyle page viewer header block

### DIFF
--- a/apps/web/src/app/pages/[pageId]/page.tsx
+++ b/apps/web/src/app/pages/[pageId]/page.tsx
@@ -23,9 +23,7 @@ export default async function ViewPagePage({
   return (
     <div className="-mx-6 -mt-8">
       <Topbar space={space} page={page} mode="read" />
-      <div className="px-6 pt-6 pb-8">
-        <PageViewer page={page} />
-      </div>
+      <PageViewer page={page} />
     </div>
   )
 }

--- a/apps/web/src/components/pages/PageViewer.tsx
+++ b/apps/web/src/components/pages/PageViewer.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { Viewer } from '@lexical-editor/editor'
-import { Badge } from '@/components/ui/badge'
+import { Clock, History } from 'lucide-react'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
-import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
 import type { Page } from '@/lib/types'
 
 function isValidEditorState(content: Record<string, unknown>): boolean {
@@ -11,16 +11,58 @@ function isValidEditorState(content: Record<string, unknown>): boolean {
   return !!root && root.type === 'root' && typeof root.version === 'number'
 }
 
-function formatDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
+function prettyTime(dateStr: string) {
+  const date = new Date(dateStr)
+  const now = Date.now()
+  const diff = now - date.getTime()
+  const minutes = Math.floor(diff / 60_000)
+  const hours = Math.floor(diff / 3_600_000)
+  const days = Math.floor(diff / 86_400_000)
+
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  if (hours < 24) return `${hours}h ago`
+  if (days < 7) return `${days}d ago`
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 function getInitials(name: string) {
-  return name.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .filter(Boolean)
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+function shortId(id: string) {
+  return id.slice(-6).toUpperCase()
+}
+
+interface StatusPillProps {
+  status: 'published' | 'draft'
+}
+
+function StatusPill({ status }: StatusPillProps) {
+  const isPublished = status === 'published'
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11.5px] font-medium',
+        isPublished ? 'bg-sage-soft text-sage-ink' : 'bg-paper-3 text-ink-2',
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          'inline-block h-1.5 w-1.5 rounded-full',
+          isPublished ? 'bg-sage' : 'bg-ink-3',
+        )}
+      />
+      {isPublished ? 'published' : 'draft'}
+    </span>
+  )
 }
 
 export function PageViewer({ page }: { page: Page }) {
@@ -34,54 +76,64 @@ export function PageViewer({ page }: { page: Page }) {
     ? page.publishedVersion.title
     : page.title
 
-  const publishedDate = page.publishedVersion?.createdAt
   const hasContent = displayContent && isValidEditorState(displayContent)
+  const versionLabel = page.publishedVersion ? `v${page.publishedVersion.version}` : null
 
   return (
-    <div>
-      <div className="border rounded-lg bg-white">
-        <h1 className="text-4xl font-bold leading-tight px-4 pt-4 pb-2">
+    <article className="max-w-[760px] mx-auto px-6 md:px-16 pt-10 md:pt-14 pb-24">
+      <header className="pb-6 border-b border-border">
+        <div className="flex items-start gap-3 mb-5">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 flex-1 min-w-0">
+            <StatusPill status={isPublished ? 'published' : 'draft'} />
+          </div>
+          <span className="mono text-[12px] uppercase tracking-wider text-ink-3 shrink-0">
+            {shortId(page.id)}
+          </span>
+        </div>
+
+        <h1 className="serif text-[40px] md:text-[54px] leading-[1.05] tracking-[-0.02em] font-normal text-foreground mb-5">
           {displayTitle}
         </h1>
 
-        <div className="flex items-center gap-3 px-4 pb-4">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-ink-2">
           {page.author && (
-            <div className="flex items-center gap-2">
-              <Avatar className="h-7 w-7">
+            <span className="flex items-center gap-2">
+              <Avatar className="h-[22px] w-[22px]">
                 <AvatarImage
-                  src={`https://api.dicebear.com/9.x/initials/svg?seed=${encodeURIComponent(page.author)}&radius=50&backgroundColor=c0aede`}
+                  src={`https://api.dicebear.com/9.x/initials/svg?seed=${encodeURIComponent(page.author)}&radius=50&backgroundColor=e8c4a0`}
                   alt={page.author}
                 />
-                <AvatarFallback className="text-xs">{getInitials(page.author)}</AvatarFallback>
+                <AvatarFallback className="text-[9px]">{getInitials(page.author)}</AvatarFallback>
               </Avatar>
-              <span className="text-sm font-medium">{page.author}</span>
-            </div>
-          )}
-          <div className="flex items-center gap-2">
-            {isPublished && page.publishedVersion ? (
-              <>
-                <Badge>Published</Badge>
-                <span className="text-xs text-muted-foreground">v{page.publishedVersion.version}</span>
-              </>
-            ) : (
-              <Badge variant="secondary">Draft</Badge>
-            )}
-          </div>
-          {publishedDate && (
-            <span className="text-xs text-muted-foreground">
-              Published {formatDate(publishedDate)}
+              <span className="font-medium text-foreground">{page.author}</span>
             </span>
           )}
+          {page.author && <span className="text-ink-3">·</span>}
+
+          <span className="flex items-center gap-1.5 text-ink-3">
+            <Clock className="h-3.5 w-3.5" />
+            updated {prettyTime(page.updatedAt)}
+          </span>
+
+          {versionLabel && (
+            <>
+              <span className="text-ink-3">·</span>
+              <span className="flex items-center gap-1.5 text-ink-3">
+                <History className="h-3.5 w-3.5" />
+                {versionLabel}
+              </span>
+            </>
+          )}
         </div>
+      </header>
 
-        <Separator />
-
+      <div className="pt-8">
         {hasContent ? (
           <Viewer initialEditorState={JSON.stringify(displayContent)} />
         ) : (
-          <div className="p-8 text-muted-foreground text-center">This page has no content yet.</div>
+          <div className="py-12 text-center text-ink-3">This page has no content yet.</div>
         )}
       </div>
-    </div>
+    </article>
   )
 }


### PR DESCRIPTION
## Summary
Restyle [`PageViewer`](apps/web/src/components/pages/PageViewer.tsx) per handoff §4.4.

- Main column: `max-w-[760px] mx-auto px-16 pt-14 pb-24`.
- Header block: meta pill row (sage \`published\` or neutral \`draft\` with dot) + right-aligned mono uppercase short page-id.
- Title: serif 54px (Instrument Serif) with tight tracking.
- Author strip: 22px avatar + ink name, `Clock` + relative \"updated N ago\", optional `History` + version label.
- Hairline `border-b` separates header from body content.
- Drop the prior white card wrapper so the cream page + article typography lead. Also removes the temporary `px-6 pt-6` wrapper in [[pageId]/page.tsx](apps/web/src/app/pages/[pageId]/page.tsx) that was fighting the new article padding.

## Deferred
Body-block styling (p / h2 / blockquote / callout / mention / landmark / code / figure / sub-pages — §4.4 table) lives in [`packages/editor/src/styles/editor.css`](packages/editor/src/styles/editor.css) and will ship with §4.6 when the editor toolbar restyle touches that file. Doing it here would cascade to every Lexical consumer (demo, rsbuild, video-converter-demo) and bloat this PR.

Stacked on top of [#24](https://github.com/StanleyLiang/knowledge-management/pull/24); base: `claude/sidebar`.

## Test plan
- [ ] `/pages/:id` shows a centered 760px article
- [ ] Draft pages show a neutral pill with a dark dot; published pages show a sage pill with a sage dot and a \`vN\` label
- [ ] Title renders in Instrument Serif at ~54px
- [ ] Mono short page-id appears top-right in uppercase
- [ ] Author strip shows avatar + name + \"updated X ago\"
- [ ] Body content still renders under the hairline divider with the existing Lexical styles