### PR TITLE
feat(web): restyle spaces dashboard and detail views

### DIFF
--- a/apps/web/src/app/spaces/[spaceId]/page.tsx
+++ b/apps/web/src/app/spaces/[spaceId]/page.tsx
@@ -2,13 +2,28 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { FileText } from 'lucide-react'
 import { api } from '@/lib/api'
-import { Badge } from '@/components/ui/badge'
 import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { TemplatePicker } from '@/components/pages/TemplatePicker'
 import { PageActions } from '@/components/pages/PageActions'
+import { SpaceGlyph } from '@/components/atoms/SpaceGlyph'
+import { cn } from '@/lib/utils'
 
 export const dynamic = 'force-dynamic'
+
+function prettyTime(dateStr: string) {
+  const date = new Date(dateStr)
+  const now = Date.now()
+  const diff = now - date.getTime()
+  const minutes = Math.floor(diff / 60_000)
+  const hours = Math.floor(diff / 3_600_000)
+  const days = Math.floor(diff / 86_400_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  if (hours < 24) return `${hours}h ago`
+  if (days < 7) return `${days}d ago`
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
 
 async function resolveSpaceId(slug: string) {
   if (slug !== 'mySpace') return slug
@@ -31,68 +46,94 @@ export default async function SpaceDetailPage({ params }: { params: Promise<{ sp
 
   return (
     <div>
-      <Breadcrumb className="mb-4">
+      <Breadcrumb className="mb-5">
         <BreadcrumbList>
           <BreadcrumbItem>
-            <BreadcrumbLink asChild><Link href="/spaces">Spaces</Link></BreadcrumbLink>
+            <BreadcrumbLink asChild>
+              <Link href="/spaces" className="text-ink-3 hover:text-foreground">Spaces</Link>
+            </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <BreadcrumbPage>{space.name}</BreadcrumbPage>
+            <BreadcrumbPage className="text-foreground">{space.name}</BreadcrumbPage>
           </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>
 
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">{space.name}</h1>
-          {space.description && <p className="text-muted-foreground mt-1">{space.description}</p>}
+      <div className="flex items-start justify-between mb-8 gap-6">
+        <div className="flex items-start gap-4 flex-1 min-w-0">
+          <SpaceGlyph name={space.name} type={space.type} size="lg" className="mt-1.5" />
+          <div className="min-w-0">
+            <h1 className="serif text-[40px] font-normal tracking-[-0.01em] leading-none text-foreground">
+              {space.name}
+            </h1>
+            {space.description && (
+              <p className="text-ink-2 mt-2.5 text-[14px] leading-relaxed">{space.description}</p>
+            )}
+          </div>
         </div>
-        <TemplatePicker spaceId={spaceId} />
+        <div className="shrink-0">
+          <TemplatePicker spaceId={spaceId} />
+        </div>
       </div>
 
       {space.pages.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">
-          <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
-          <p>No pages yet. Create one to get started.</p>
+        <div className="text-center py-16 bg-paper-2 border border-border rounded-[14px]">
+          <FileText className="h-8 w-8 mx-auto mb-3 text-ink-3" />
+          <p className="text-[13px] text-ink-2">No pages yet. Create one to get started.</p>
         </div>
       ) : (
-        <div className="border rounded-lg bg-white">
+        <div className="bg-background border border-border rounded-[14px] overflow-hidden">
           <Table>
             <TableHeader>
-              <TableRow>
-                <TableHead>Title</TableHead>
-                <TableHead>Author</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Updated</TableHead>
+              <TableRow className="bg-paper-2 hover:bg-paper-2">
+                <TableHead className="text-[11px] uppercase tracking-[0.08em] text-ink-3 font-semibold">Title</TableHead>
+                <TableHead className="text-[11px] uppercase tracking-[0.08em] text-ink-3 font-semibold">Author</TableHead>
+                <TableHead className="text-[11px] uppercase tracking-[0.08em] text-ink-3 font-semibold">Status</TableHead>
+                <TableHead className="text-[11px] uppercase tracking-[0.08em] text-ink-3 font-semibold">Updated</TableHead>
                 <TableHead className="w-10" />
               </TableRow>
             </TableHeader>
             <TableBody>
-              {space.pages.map((page) => (
-                <TableRow key={page.id}>
-                  <TableCell>
-                    <Link href={`/pages/${page.id}`} className="flex items-center gap-2 hover:underline">
-                      <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <span className="font-medium">{page.title}</span>
-                    </Link>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">
-                    {page.author ?? '—'}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={page.status === 'PUBLISHED' ? 'default' : 'secondary'} className="text-xs">
-                      {page.status.toLowerCase()}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">
-                    {new Date(page.updatedAt).toLocaleDateString()}
-                  </TableCell>
-                  <TableCell>
-                    <PageActions pageId={page.id} />
-                  </TableCell>
-                </TableRow>
-              ))}
+              {space.pages.map((page) => {
+                const isPublished = page.status === 'PUBLISHED'
+                return (
+                  <TableRow key={page.id} className="h-12 hover:bg-paper-3">
+                    <TableCell className="py-0">
+                      <Link href={`/pages/${page.id}`} className="flex items-center gap-2.5 text-[13.5px] text-foreground hover:text-foreground">
+                        <FileText className="h-4 w-4 text-ink-3 shrink-0" />
+                        <span className="font-medium truncate">{page.title}</span>
+                      </Link>
+                    </TableCell>
+                    <TableCell className="py-0 text-[13px] text-ink-2">
+                      {page.author ?? '—'}
+                    </TableCell>
+                    <TableCell className="py-0">
+                      <span
+                        className={cn(
+                          'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11.5px] font-medium',
+                          isPublished ? 'bg-sage-soft text-sage-ink' : 'bg-paper-3 text-ink-2',
+                        )}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            'inline-block h-1.5 w-1.5 rounded-full',
+                            isPublished ? 'bg-sage' : 'bg-ink-3',
+                          )}
+                        />
+                        {page.status.toLowerCase()}
+                      </span>
+                    </TableCell>
+                    <TableCell className="py-0 text-[13px] text-ink-3">
+                      {prettyTime(page.updatedAt)}
+                    </TableCell>
+                    <TableCell className="py-0">
+                      <PageActions pageId={page.id} />
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
             </TableBody>
           </Table>
         </div>

--- a/apps/web/src/app/spaces/page.tsx
+++ b/apps/web/src/app/spaces/page.tsx
@@ -1,46 +1,89 @@
 import Link from 'next/link'
-import { Folder } from 'lucide-react'
+import { FileText, Clock } from 'lucide-react'
 import { api } from '@/lib/api'
-import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { SpaceGlyph } from '@/components/atoms/SpaceGlyph'
 import { CreateSpaceDialog } from '@/components/spaces/CreateSpaceDialog'
 
 export const dynamic = 'force-dynamic'
+
+function prettyTime(dateStr: string) {
+  const date = new Date(dateStr)
+  const now = Date.now()
+  const diff = now - date.getTime()
+  const minutes = Math.floor(diff / 60_000)
+  const hours = Math.floor(diff / 3_600_000)
+  const days = Math.floor(diff / 86_400_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  if (hours < 24) return `${hours}h ago`
+  if (days < 7) return `${days}d ago`
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
 
 export default async function SpacesPage() {
   const spaces = await api.spaces.list()
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Spaces</h1>
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="serif text-[36px] font-normal tracking-[-0.01em] leading-none text-foreground">
+            Spaces
+          </h1>
+          <p className="text-[13px] text-ink-3 mt-2">
+            {spaces.length} {spaces.length === 1 ? 'space' : 'spaces'} in your knowledge base
+          </p>
+        </div>
         <CreateSpaceDialog />
       </div>
 
       {spaces.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">
-          <Folder className="h-12 w-12 mx-auto mb-4 opacity-50" />
-          <p>No spaces yet. Create one to get started.</p>
+        <div className="text-center py-16 bg-paper-2 border border-border rounded-[14px]">
+          <div className="mx-auto mb-4 flex items-center justify-center">
+            <SpaceGlyph name="Welcome" size="lg" />
+          </div>
+          <p className="text-[13px] text-ink-2">No spaces yet. Create one to get started.</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {spaces.map((space) => (
-            <Link key={space.id} href={`/spaces/${space.id}`}>
-              <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Folder className="h-5 w-5 text-blue-500" />
-                    {space.name}
-                  </CardTitle>
-                  {space.description && (
-                    <CardDescription>{space.description}</CardDescription>
-                  )}
-                  <CardDescription>
-                    {space._count?.pages ?? 0} page{(space._count?.pages ?? 0) !== 1 ? 's' : ''}
-                  </CardDescription>
-                </CardHeader>
-              </Card>
-            </Link>
-          ))}
+          {spaces.map((space) => {
+            const count = space._count?.pages ?? 0
+            return (
+              <Link
+                key={space.id}
+                href={`/spaces/${space.id}`}
+                className="group block bg-paper-2 border border-border rounded-[14px] p-5 hover:bg-paper-3 hover:shadow-sm transition-all"
+              >
+                <div className="flex items-start gap-3 mb-4">
+                  <SpaceGlyph name={space.name} type={space.type} size="lg" />
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-[17px] text-foreground truncate">
+                      {space.name}
+                    </div>
+                    <div className="mono text-[10.5px] uppercase tracking-wider text-ink-3 mt-0.5">
+                      {space.type.toLowerCase()}
+                    </div>
+                  </div>
+                </div>
+
+                {space.description && (
+                  <p className="text-[13px] text-ink-2 mb-4 line-clamp-2">{space.description}</p>
+                )}
+
+                <div className="flex items-center gap-3 text-[12px] text-ink-3">
+                  <span className="flex items-center gap-1.5">
+                    <FileText className="h-3.5 w-3.5" />
+                    {count} {count === 1 ? 'page' : 'pages'}
+                  </span>
+                  <span>·</span>
+                  <span className="flex items-center gap-1.5">
+                    <Clock className="h-3.5 w-3.5" />
+                    updated {prettyTime(space.updatedAt)}
+                  </span>
+                </div>
+              </Link>
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
Applies Atelier look to /spaces and /spaces/[id]: SpaceGlyph-led paper-2 cards with stats row, serif h1s, and a warm table (48px rows, sage/neutral status pills, paper-2 header). Stacked on #29.