### PR TITLE
feat(editor): atelier toolbar styling + scoped prose theme

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -72,3 +72,88 @@
   .serif { font-family: var(--font-serif); font-weight: 400; letter-spacing: -0.01em; }
   .mono { font-family: var(--font-mono); font-feature-settings: "tnum", "zero"; }
 }
+
+/* ==========================================================================
+   Atelier prose — overrides for body blocks when rendered inside a
+   .prose-atelier wrapper (Viewer + Editor). Scoped so the shared editor.css
+   defaults stay intact for demo / rsbuild consumers.
+   ========================================================================== */
+@layer base {
+  .prose-atelier .le-paragraph {
+    font-size: 16.5px;
+    line-height: 1.7;
+    color: var(--color-foreground);
+    margin-bottom: 1em;
+  }
+  .prose-atelier .le-heading-h1 {
+    font-family: var(--font-serif);
+    font-weight: 400;
+    font-size: 2.2rem;
+    letter-spacing: -0.01em;
+    margin: 2rem 0 0.8rem;
+  }
+  .prose-atelier .le-heading-h2 {
+    font-family: var(--font-serif);
+    font-weight: 400;
+    font-size: 1.65rem;
+    letter-spacing: -0.01em;
+    margin: 1.6rem 0 0.6rem;
+  }
+  .prose-atelier .le-heading-h3 {
+    font-family: var(--font-serif);
+    font-weight: 400;
+    font-size: 1.3rem;
+    margin: 1.3rem 0 0.4rem;
+  }
+  .prose-atelier .le-heading-h4,
+  .prose-atelier .le-heading-h5,
+  .prose-atelier .le-heading-h6 {
+    font-weight: 600;
+    color: var(--color-ink-2);
+    text-transform: none;
+  }
+  .prose-atelier .le-quote {
+    border-left-width: 3px;
+    border-color: var(--color-terracotta);
+    background: var(--color-terracotta-soft);
+    padding: 12px 18px;
+    color: var(--color-foreground);
+    font-style: normal;
+    border-radius: 0 8px 8px 0;
+    margin: 1.2em 0;
+  }
+  .prose-atelier .le-text-code {
+    background: var(--color-paper-3);
+    color: var(--color-foreground);
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    border-radius: 4px;
+  }
+  .prose-atelier .le-link {
+    color: var(--color-terracotta);
+    text-decoration-color: color-mix(in oklab, var(--color-terracotta) 40%, transparent);
+  }
+  .prose-atelier .le-link:hover {
+    color: var(--color-terracotta);
+    text-decoration-color: var(--color-terracotta);
+  }
+  .prose-atelier .le-mention {
+    background: var(--color-plum-soft);
+    color: var(--color-plum);
+    border-radius: 6px;
+    padding: 1px 6px;
+    font-weight: 500;
+  }
+  .prose-atelier .le-landmark-tag {
+    background: var(--color-terracotta-soft);
+    color: var(--color-terracotta);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+  }
+  .prose-atelier .le-code-snippet {
+    background: var(--color-paper-2);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+  }
+}

--- a/apps/web/src/components/pages/PageEditor.tsx
+++ b/apps/web/src/components/pages/PageEditor.tsx
@@ -183,7 +183,7 @@ export function PageEditor({ pageId }: { pageId: string }) {
           </Button>
         </div>
       </div>
-      <div className="border rounded-lg bg-white">
+      <div className="border rounded-lg bg-white prose-atelier">
         <Editor
           title={title}
           onTitleChange={handleTitleChange}

--- a/apps/web/src/components/pages/PageViewer.tsx
+++ b/apps/web/src/components/pages/PageViewer.tsx
@@ -127,7 +127,7 @@ export function PageViewer({ page }: { page: Page }) {
         </div>
       </header>
 
-      <div className="pt-8">
+      <div className="pt-8 prose-atelier">
         {hasContent ? (
           <Viewer initialEditorState={JSON.stringify(displayContent)} />
         ) : (

--- a/packages/editor/src/components/editor/Toolbar.tsx
+++ b/packages/editor/src/components/editor/Toolbar.tsx
@@ -40,6 +40,7 @@ import {
   Link,
   MoreHorizontal,
   ChevronDown,
+  Plus,
   Type,
   Heading1,
   Heading2,
@@ -223,8 +224,30 @@ export function Toolbar() {
     })
   }
 
+  const triggerSlashPopover = () => {
+    editor.focus()
+    editor.update(() => {
+      const selection = $getSelection()
+      if (!$isRangeSelection(selection)) return
+      selection.insertText('/')
+    })
+  }
+
   return (
     <div className="le-toolbar">
+      {/* Prominent Insert button — opens slash-command popover */}
+      <Tooltip content={t('toolbar.insert', { defaultValue: 'Insert' })}>
+        <button
+          type="button"
+          className="le-toolbar-insert"
+          onClick={triggerSlashPopover}
+        >
+          <Plus size={14} />
+          {t('toolbar.insert', { defaultValue: 'Insert' })}
+          <span className="le-toolbar-insert-kbd">/</span>
+        </button>
+      </Tooltip>
+
       {/* Hidden file inputs for upload */}
       <input
         ref={imageInputRef}

--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -436,11 +436,32 @@
 
 /* ========== Toolbar ========== */
 .le-toolbar {
-  @apply flex items-center gap-0.5 px-2 py-1 border-b border-gray-200 bg-gray-50
-         rounded-t-lg flex-wrap sticky top-0 z-40;
+  @apply flex items-center gap-0.5 px-2.5 py-[7px] border-b border-gray-200
+         bg-white/90 flex-wrap sticky top-0 z-40;
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
 }
 .le-toolbar-dropdown-trigger {
   @apply flex items-center gap-1;
+}
+.le-toolbar-insert {
+  @apply inline-flex items-center gap-1.5 rounded-[8px] px-[10px] py-[5px]
+         text-[12.5px] font-medium mr-1.5;
+  background: oklch(0.94 0.03 40);
+  color: oklch(0.38 0.1 30);
+}
+.le-toolbar-insert:hover {
+  background: oklch(0.91 0.04 40);
+}
+.le-toolbar-insert-kbd {
+  @apply font-mono text-[10.5px] opacity-70 ml-0.5;
+}
+.le-toolbar-saved {
+  @apply ml-auto flex items-center gap-1.5 text-[11px] text-gray-500 pr-1;
+}
+.le-toolbar-saved-dot {
+  @apply inline-block h-1.5 w-1.5 rounded-full;
+  background: oklch(0.75 0.12 150);
 }
 /* ========== Custom Nodes ========== */
 


### PR DESCRIPTION
Final slice of the Atelier pass. Restyles le-toolbar (glass bg, tighter padding), adds a terracotta Insert button that summons the slash popover, and introduces a .prose-atelier scope in apps/web globals.css so body blocks (paragraph, headings, quote, code, link, mention, landmark) adopt the warm palette only inside the knowledge-management app — demo/rsbuild consumers keep the neutral defaults. Stacked on #30.