### PR TITLE
feat(web): rebrand Atelier → Keeptio

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -74,7 +74,7 @@
 }
 
 /* ==========================================================================
-   Atelier prose — overrides for body blocks when rendered inside a
+   Keeptio prose — overrides for body blocks when rendered inside a
    .prose-atelier wrapper (Viewer + Editor). Scoped so the shared editor.css
    defaults stay intact for demo / rsbuild consumers.
    ========================================================================== */

--- a/apps/web/src/app/icon.svg
+++ b/apps/web/src/app/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect x="0" y="0" width="120" height="120" rx="22" fill="oklch(0.66 0.14 40)"/>
+  <path d="M 40 22 L 40 98" stroke="oklch(0.95 0.045 85)" stroke-width="16" stroke-linecap="round" fill="none"/>
+  <g fill="none" stroke-linecap="round">
+    <g transform="translate(60 46) rotate(-28)">
+      <rect x="-20" y="-10" width="40" height="20" rx="10" stroke="oklch(0.52 0.09 70)" stroke-width="8"/>
+    </g>
+    <g transform="translate(60 74) rotate(28)">
+      <rect x="-20" y="-10" width="40" height="20" rx="10" stroke="oklch(0.74 0.10 75)" stroke-width="8"/>
+    </g>
+  </g>
+  <path d="M 40 36 L 40 84" stroke="oklch(0.95 0.045 85)" stroke-width="16" stroke-linecap="round" fill="none"/>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -17,8 +17,8 @@ const instrumentSerif = Instrument_Serif({
 const jetMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' })
 
 export const metadata: Metadata = {
-  title: 'Knowledge Base',
-  description: 'Knowledge Base powered by Lexical Editor',
+  title: 'Keeptio',
+  description: 'Keeptio — kept within reach',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -33,7 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <div className="flex items-center gap-6">
                 <Link href="/spaces" className="flex items-center gap-2 font-bold text-lg">
                   <BookOpen className="h-5 w-5" />
-                  Knowledge Base
+                  Keeptio
                 </Link>
                 <Link
                   href="/syntheses"

--- a/apps/web/src/components/brand/KeeptioMark.tsx
+++ b/apps/web/src/components/brand/KeeptioMark.tsx
@@ -1,0 +1,124 @@
+import type { SVGProps } from 'react'
+
+interface KeeptioMarkProps extends Omit<SVGProps<SVGSVGElement>, 'width' | 'height'> {
+  size?: number
+  rounded?: boolean
+  onInk?: boolean
+}
+
+export function KeeptioMark({
+  size = 28,
+  rounded = true,
+  onInk = false,
+  ...rest
+}: KeeptioMarkProps) {
+  const tileFill = onInk ? 'oklch(0.22 0.020 60)' : 'var(--color-terracotta, oklch(0.66 0.14 40))'
+  const stemColor = onInk ? 'var(--color-terracotta, oklch(0.66 0.14 40))' : 'oklch(0.95 0.045 85)'
+  const linkUp = onInk ? 'oklch(0.74 0.10 75)' : 'oklch(0.52 0.09 70)'
+  const linkDn = onInk ? 'oklch(0.52 0.09 70)' : 'oklch(0.74 0.10 75)'
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...rest}
+    >
+      {rounded ? (
+        <rect x="0" y="0" width="120" height="120" rx="28" fill={tileFill} />
+      ) : (
+        <circle cx="60" cy="60" r="60" fill={tileFill} />
+      )}
+      <path
+        d="M 40 26 L 40 94"
+        stroke={stemColor}
+        strokeWidth="9"
+        strokeLinecap="round"
+        fill="none"
+      />
+      <g fill="none" strokeLinecap="round" strokeLinejoin="round">
+        <g transform="translate(60 46) rotate(-28)">
+          <rect x="-18" y="-9" width="36" height="18" rx="9" stroke={linkUp} strokeWidth="6" />
+        </g>
+        <g transform="translate(60 74) rotate(28)">
+          <rect x="-18" y="-9" width="36" height="18" rx="9" stroke={linkDn} strokeWidth="6" />
+        </g>
+        <path d="M 58 58 Q 63 60, 66 64" stroke={linkUp} strokeWidth="6" />
+      </g>
+      <path
+        d="M 40 40 L 40 80"
+        stroke={stemColor}
+        strokeWidth="9"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  )
+}
+
+export function KeeptioMarkMicro({
+  size = 16,
+  ...rest
+}: Omit<KeeptioMarkProps, 'rounded' | 'onInk'>) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...rest}
+    >
+      <rect
+        x="0"
+        y="0"
+        width="120"
+        height="120"
+        rx="22"
+        fill="var(--color-terracotta, oklch(0.66 0.14 40))"
+      />
+      <path
+        d="M 40 22 L 40 98"
+        stroke="oklch(0.95 0.045 85)"
+        strokeWidth="16"
+        strokeLinecap="round"
+        fill="none"
+      />
+      <g fill="none" strokeLinecap="round">
+        <g transform="translate(60 46) rotate(-28)">
+          <rect
+            x="-20"
+            y="-10"
+            width="40"
+            height="20"
+            rx="10"
+            stroke="oklch(0.52 0.09 70)"
+            strokeWidth="8"
+          />
+        </g>
+        <g transform="translate(60 74) rotate(28)">
+          <rect
+            x="-20"
+            y="-10"
+            width="40"
+            height="20"
+            rx="10"
+            stroke="oklch(0.74 0.10 75)"
+            strokeWidth="8"
+          />
+        </g>
+      </g>
+      <path
+        d="M 40 36 L 40 84"
+        stroke="oklch(0.95 0.045 85)"
+        strokeWidth="16"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  )
+}

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -25,6 +25,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Skeleton } from '@/components/ui/skeleton'
 import { SpaceGlyph } from '@/components/atoms/SpaceGlyph'
+import { KeeptioMark } from '@/components/brand/KeeptioMark'
 import { cn } from '@/lib/utils'
 import { api } from '@/lib/api'
 import type { Space, SpaceWithPages, PageSummary } from '@/lib/types'
@@ -307,20 +308,14 @@ export function AppSidebar() {
     <aside className="w-[268px] flex-shrink-0 flex flex-col border-r border-border bg-gradient-to-b from-[oklch(0.975_0.014_78)] to-[oklch(0.955_0.018_78)]">
       {/* Brand block */}
       <div className="px-3 pt-3 pb-2 flex items-center gap-2.5">
-        <span
-          aria-hidden="true"
-          className="inline-flex items-center justify-center h-[26px] w-[26px] rounded-lg text-background serif text-[17px] leading-none"
-          style={{
-            backgroundImage:
-              'radial-gradient(circle at 30% 30%, oklch(0.78 0.10 40), oklch(0.50 0.16 40))',
-          }}
-        >
-          A
-        </span>
+        <KeeptioMark
+          size={26}
+          className="rounded-lg shadow-[0_1px_1px_oklch(0.3_0.05_40/0.18)]"
+        />
         <span className="flex flex-col leading-tight min-w-0">
-          <span className="serif text-[17px] text-foreground">Atelier</span>
+          <span className="serif text-[17px] text-foreground">Keeptio</span>
           <span className="text-[10px] uppercase tracking-[0.08em] text-ink-3">
-            Knowledge base
+            Kept within reach
           </span>
         </span>
       </div>


### PR DESCRIPTION
## Summary
- Add reusable `<KeeptioMark>` component (full + micro variants) with typed props `{ size, rounded, onInk, className }` — terracotta tile with cream K stem threaded by interlocked brass chain links.
- Swap sidebar brand row: old "A" avatar + "Atelier" wordmark + "Knowledge base" → KeeptioMark + "Keeptio" + "Kept within reach".
- Update root layout: document title to `Keeptio`, description, and top-nav label; add Next.js file-convention `app/icon.svg` favicon derived from the micro mark.
- Rename the prose overrides comment in `globals.css` to "Keeptio prose" (CSS class name stays `.prose-atelier` to avoid touching every call site — purely internal).

Per the handoff at `design_handoff_keeptio_rebrand/README.md` §4.4 and §4.5. One small PR.

## Test plan
- [x] Sidebar renders new KeeptioMark with Keeptio wordmark and "KEPT WITHIN REACH" tagline
- [x] Top nav shows "Keeptio" next to the BookOpen icon
- [x] Browser tab title reads "Keeptio"
- [x] `app/icon.svg` served as favicon
- [x] No console errors on `/spaces/mySpace`
- [ ] Reviewer sanity check at other routes (page view/edit, syntheses)